### PR TITLE
Redirect "om <secpath> ed" to edit config

### DIFF
--- a/lib/data.py
+++ b/lib/data.py
@@ -118,6 +118,9 @@ class DataMixin(object):
             tmpf.close()
 
     def edit(self):
+        if self.options.key is None:
+            self.edit_config()
+            return
         buff = self.decode_key(self.options.key)
         if buff is None:
             raise ex.excError("could not decode the secret key '%s'" % self.options.key)


### PR DESCRIPTION
The "ed" action is now entering the Data::edit() codepath, which fail because
no key is set in options.

Instead of failing, redirect to Data::edit_config(), which is the codepath
that was entered before the "edit --key <k>" action was added.