### PR TITLE
Fix an issue in event delivery to clients

### DIFF
--- a/lib/osvcd_lsnr.py
+++ b/lib/osvcd_lsnr.py
@@ -493,6 +493,8 @@ class Listener(shared.OsvcThread):
                 fevent = self.filter_event(event, thr)
                 if fevent is None:
                     continue
+                # make a copy to avoid being replaced while queued
+                fevent = json.loads(json.dumps(fevent))
                 if thr.h2conn:
                     if not thr.events_stream_ids:
                         to_remove.append(idx)


### PR DESCRIPTION
In a fast succession of events, a n+1 event could overwrite the n event data
for a client.

Make a copy of the dequeue event before putting the copy in the client queue,
to avoid being replaced while queued.