### PR TITLE
Don't start/stop task.type=oci containers on start/stop

### DIFF
--- a/lib/resTaskDocker.py
+++ b/lib/resTaskDocker.py
@@ -12,6 +12,12 @@ class Task(resContainerDocker.Container, resTask.Task):
 
     _info = resContainerDocker.Container._info
 
+    def start(self):
+        resTask.Task.start(self)
+
+    def stop(self):
+        resTask.Task.stop(self)
+
     def _run_call(self):
         try:
             resContainerDocker.Container.start(self)


### PR DESCRIPTION
Use the resTask start/stop method instead of the resContainer implementation.

As the resTaskDocker class inherits from the resTask and the resContainerDocker
driver, explicitely choose the start/stop implementation to use.