### PR TITLE
Fix a stack sorting fs.dir and fs.flag resources in the same object

### DIFF
--- a/lib/resFs.py
+++ b/lib/resFs.py
@@ -236,8 +236,11 @@ class Mount(Res.Resource):
         Order so that deepest mountpoint can be umount first.
         If no ordering constraint, honor the rid order.
         """
-        smnt = os.path.dirname(self.mount_point)
-        omnt = os.path.dirname(other.mount_point)
+        try:
+            smnt = os.path.dirname(self.mount_point)
+            omnt = os.path.dirname(other.mount_point)
+        except AttributeError:
+            return self.rid < other.rid
         return (smnt, self.rid) < (omnt, other.rid)
 
     @lazy

--- a/lib/resFsDir.py
+++ b/lib/resFsDir.py
@@ -125,10 +125,12 @@ class FsDir(Res.Resource):
 
     def __lt__(self, other):
         """
-        Order so that deepest mountpoint can be umount first
+        Order so that deepest mountpoint can be umount first.
+        If no ordering constraint, honor the rid order.
         """
-        return self.mount_point < other.mount_point
-
-
-
-
+        try:
+            smnt = os.path.dirname(self.mount_point)
+            omnt = os.path.dirname(other.mount_point)
+        except AttributeError:
+            return self.rid < other.rid
+        return (smnt, self.rid) < (omnt, other.rid)

--- a/lib/svc.py
+++ b/lib/svc.py
@@ -5612,7 +5612,11 @@ class Svc(BaseSvc):
         candidates = [res for res in self.get_resources("fs")]
         if not candidates:
             return
-        return sorted(candidates)[0].mount_point
+        for candidate in sorted(candidates):
+            if not hasattr(candidate, "mount_point"):
+                continue
+            return candidate.mount_point
+        raise IndexError
 
     def device(self):
         """


### PR DESCRIPTION
Catch AttributeError from resFs __lt__ when comparing mount_point attrs, as
this attribute may not exist in all fs drivers (ex: fs.flag).

Resync the resFsDir __lt__ definition from resFs.

Do not return the first fs resource mount point as the volume mount point, as
the first fs resource might not have a mount_point attribute. Return the
mount point of the first fs resource with a mount_point attribute instead.