### PR TITLE
Allow Uppercase in config file keys

### DIFF
--- a/lib/extconfig.py
+++ b/lib/extconfig.py
@@ -205,7 +205,7 @@ class ExtConfigMixin(object):
             if "=" not in kw:
                 raise ex.excError("malformed kw expression: %s: no '='" % kw)
             keyword, value = kw.split("=", 1)
-            if 'DEFAULT' not in keyword:
+            if 'DEFAULT' not in keyword and not keyword.startswith("data."):
                 keyword = keyword.lower()
             if keyword[-1] == "-":
                 op = "remove"

--- a/lib/hb_ucast.py
+++ b/lib/hb_ucast.py
@@ -23,7 +23,7 @@ class HbUcast(Hb):
 
     def status(self, **kwargs):
         data = Hb.status(self, **kwargs)
-        data["stats"]= self.stats
+        data["stats"] = self.stats
         data["config"] = {
             "timeout": self.timeout,
         }
@@ -139,7 +139,7 @@ class HbUcastTx(HbUcast):
             self.push_stats()
             if self.get_last(nodename).success:
                 self.log.warning("send to %s (%s:%d) error: %s", nodename,
-                               config["addr"], config["port"], str(exc))
+                                 config["addr"], config["port"], str(exc))
             self.set_last(nodename, success=False)
         finally:
             self.set_beating(nodename)
@@ -160,13 +160,15 @@ class HbUcastRx(HbUcast):
         self.config_change = False
         if self.sock:
             self.sock.close()
+        lexc = None
         for _ in range(3):
             try:
                 self.configure_listener()
                 return
             except socket.error as exc:
+                lexc = exc
                 time.sleep(1)
-        self.log.error("init error: %s", str(exc))
+        self.log.error("init error: %s", str(lexc))
         raise ex.excAbortAction
 
     def configure_listener(self):
@@ -243,7 +245,7 @@ class HbUcastRx(HbUcast):
         if nodename is None or nodename == rcEnv.nodename:
             # ignore hb data we sent ourself
             return
-        elif nodename not in self.hb_nodes:
+        if nodename not in self.hb_nodes:
             return
         if data is None:
             self.push_stats()
@@ -258,6 +260,3 @@ class HbUcastRx(HbUcast):
             self.set_last(nodename, success=False)
         finally:
             self.set_beating(nodename)
-
-
-

--- a/lib/rcUtilities.py
+++ b/lib/rcUtilities.py
@@ -1048,6 +1048,7 @@ def read_cf(fpaths, defaults=None):
     if defaults is None:
         defaults = {}
     config = RawConfigParser(defaults)
+    config.optionxform = str
     if not isinstance(fpaths, (list, tuple)):
         fpaths = [fpaths]
     for fpath in fpaths:


### PR DESCRIPTION
At least data section needs to store keys in secrets and configmaps respecting
user-intended naming (like file names and path).