### PR TITLE
Fix relay query when --node option is not set

### DIFF
--- a/lib/node.py
+++ b/lib/node.py
@@ -4099,7 +4099,7 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
                     relay = self.conf_get(section, "relay")
                 except (ValueError, ex.OptNotFound):
                     continue
-                if relay != self.options.node:
+                if relay not in self.options.server:
                     continue
                 try:
                     secret = self.conf_get(section, "secret")


### PR DESCRIPTION
om node daemon relay status --server raw://relay.opensvc.com