### PR TITLE
Fix the scsireserv registered count for multi-lun resources

### DIFF
--- a/lib/resScsiReserv.py
+++ b/lib/resScsiReserv.py
@@ -110,8 +110,8 @@ class ScsiReserv(Res.Resource):
     def get_devs(self):
         if len(self.devs) > 0:
             return
-        self.devs = self.peer_resource.sub_devs()
-        self.devs = self.mangle_devs(self.devs)
+        self.peer_sub_devs = self.peer_resource.sub_devs()
+        self.devs = self.mangle_devs(self.peer_sub_devs)
 
     def ack_all_unit_attention(self):
         self.get_devs()

--- a/lib/resScsiReservSg.py
+++ b/lib/resScsiReservSg.py
@@ -63,17 +63,21 @@ class ScsiReserv(resScsiReserv.ScsiReserv):
         return ret, out, err
 
     def read_registrations(self):
-        for dev in self.devs:
-            ret, out, err = self.read_path_registrations(dev)
-            if ret != 0:
-                continue
-            return out
-        raise ""
+        n_devs = 0
+        n_registered = 0
+        for sub_dev in self.peer_sub_devs:
+            devs = self.mangle_devs(sub_dev)
+            for dev in devs:
+                ret, out, err = self.read_path_registrations(dev)
+                if ret != 0:
+                    continue
+                n_devs += len(devs)
+                n_registered = out.count(self.hostid)
+                break
+        return n_devs, n_registered
 
     def check_all_paths_registered(self):
-        out = self.read_registrations()
-        n_registered = out.count(self.hostid)
-        n_devs = len(self.devs)
+        n_devs, n_registered = self.read_registrations()
         if n_registered == n_devs:
             return
         if n_registered == 0:


### PR DESCRIPTION
Example:

With 1 registration down on 1/2 luns, we reported 1/4 instead of 3/4

root@ringfs-1:/opt/opensvc# om test/svc/svc100 print status -r
test/svc/svc100                   warn       warn
`- instances
   `- ringfs-1                    warn       warn, frozen, idle
      |- disk#0          ........ down       vg svc100.test.svc.ringfs
      `- disk#0pr        ........ warn       /dev/sde, /dev/sdh, /dev/sdp, /dev/sds
                                             warn: 1/4 paths registered