### PR TITLE
Fix the test for registration keys count

### DIFF
--- a/lib/resScsiReservSg.py
+++ b/lib/resScsiReservSg.py
@@ -66,13 +66,13 @@ class ScsiReserv(resScsiReserv.ScsiReserv):
         n_devs = 0
         n_registered = 0
         for sub_dev in self.peer_sub_devs:
-            devs = self.mangle_devs(sub_dev)
+            devs = self.mangle_devs([sub_dev])
             for dev in devs:
                 ret, out, err = self.read_path_registrations(dev)
                 if ret != 0:
                     continue
                 n_devs += len(devs)
-                n_registered = out.count(self.hostid)
+                n_registered += out.count(self.hostid)
                 break
         return n_devs, n_registered
 


### PR DESCRIPTION
Increment the registered counter instead of resetting it for each disk.
And pass a list to mangle_devs() instead of a string.