### PR TITLE
Disable volume sync#i0 if it contains no resource with files to sync

### DIFF
--- a/lib/poolDirectory.py
+++ b/lib/poolDirectory.py
@@ -24,7 +24,6 @@ class Pool(pool.Pool):
                 "size": size,
             }
         ]
-        data += self.add_sync_internal(data)
         return data
 
     def translate(self, name=None, size=None, fmt=True, shared=False):

--- a/lib/poolDorado.py
+++ b/lib/poolDorado.py
@@ -147,7 +147,6 @@ class Pool(pool.Pool):
         data.append(disk)
         if fmt:
             data += self.add_fs(name, shared)
-        data += self.add_sync_internal(data)
         return data
 
 

--- a/lib/poolFreenas.py
+++ b/lib/poolFreenas.py
@@ -68,7 +68,6 @@ class Pool(pool.Pool):
         data.append(disk)
         if fmt:
             data += self.add_fs(name, shared)
-        data += self.add_sync_internal(data)
         return data
 
     @lazy

--- a/lib/poolLoop.py
+++ b/lib/poolLoop.py
@@ -25,7 +25,6 @@ class Pool(pool.Pool):
         ]
         if fmt:
             data += self.add_fs(name, shared)
-        data += self.add_sync_internal(data)
         return data
 
     def pool_status(self):

--- a/lib/poolShare.py
+++ b/lib/poolShare.py
@@ -24,7 +24,6 @@ class Pool(pool.Pool):
                 "size": size,
             }
         ]
-        data += self.add_sync_internal(data)
         return data
 
     def translate(self, name=None, size=None, fmt=True, shared=False):

--- a/lib/poolShm.py
+++ b/lib/poolShm.py
@@ -25,7 +25,6 @@ class Pool(pool.Pool):
                 "size": size,
             }
         ]
-        data += self.add_sync_internal(data)
         return data
 
     def translate(self, name=None, size=None, fmt=True, shared=False):


### PR DESCRIPTION
Instead of the previous incomplete white-list implementation.

For example, a xfs over dorado volume had its sync#i0 active with the
previous implementation.