### PR TITLE
Add mpathpersist support

### DIFF
--- a/lib/resScsiReservFreeBSD.py
+++ b/lib/resScsiReservFreeBSD.py
@@ -3,7 +3,4 @@ from rcUtilitiesLinux import dev_to_paths
 
 class ScsiReserv(resScsiReservSg.ScsiReserv):
     def mangle_devs(self, devs):
-        _devs = set()
-        for dev in devs:
-            _devs |= set(dev_to_paths(dev))
-        return _devs
+        return dict((dev, dev_to_paths(dev)) for dev in devs)

--- a/lib/resScsiReservLinux.py
+++ b/lib/resScsiReservLinux.py
@@ -3,19 +3,20 @@ import rcStatus
 from rcUtilitiesLinux import dev_to_paths, dev_is_ro
 
 class ScsiReserv(resScsiReservSg.ScsiReserv):
+
+
     def mangle_devs(self, devs):
-        _devs = set()
-        for dev in devs:
-            _devs |= set(dev_to_paths(dev))
-        return _devs
+        return dict((dev, dev_to_paths(dev)) for dev in devs)
+
 
     def _status(self, verbose=False):
         ret = resScsiReservSg.ScsiReserv._status(self, verbose=verbose)
         if ret != rcStatus.UP:
             return ret
         self.get_devs()
-        for dev in self.devs:
-            if dev_is_ro(dev):
-                self.status_log("resv held on ro dev %s" % dev, "info")
-                return rcStatus.NA
+        for dev, paths in self.devs.items():
+            for path in paths:
+                if dev_is_ro(path):
+                    self.status_log("resv held on ro dev %s in %s" % (path, dev), "info")
+                    return rcStatus.NA
         return ret

--- a/lib/resScsiReservOSF1.py
+++ b/lib/resScsiReservOSF1.py
@@ -29,7 +29,9 @@ class ScsiReserv(resScsiReserv.ScsiReserv):
     def get_devs(self):
         if len(self.devs) > 0:
             return
-        self.devs = map(lambda x: str(x.replace('/disk/', '/rdisk/')), self.peer_resource.sub_devs())
+        for dev in self.peer_resource.sub_devs():
+            dev = dev.replace('/disk/', '/rdisk/')
+            self.devs[dev] = [dev]
 
     def scsireserv_supported(self):
         if which('scu') is None:

--- a/lib/resScsiReservSg.py
+++ b/lib/resScsiReservSg.py
@@ -5,7 +5,7 @@ import re
 import time
 import rcStatus
 import rcExceptions as ex
-from rcUtilities import which, bdecode
+from rcUtilities import which, bdecode, lazy
 from subprocess import *
 import resScsiReserv
 from rcGlobalEnv import rcEnv
@@ -13,10 +13,11 @@ from rcGlobalEnv import rcEnv
 
 class ScsiReserv(resScsiReserv.ScsiReserv):
     def scsireserv_supported(self):
-        if which('sg_persist') is None:
-            self.status_log("sg_persist must be installed to use scsi-3 reservations" )
+        if which("sg_persist") is None and which("mpathpersist") is None:
+            self.status_log("sg_persist or mpathpersist must be installed to use scsi-3 reservations")
             return False
         return True
+
 
     def set_read_only(self, val):
         if rcEnv.sysname != "Linux":
@@ -24,14 +25,17 @@ class ScsiReserv(resScsiReserv.ScsiReserv):
         os.environ["SG_PERSIST_O_RDONLY"] = str(val)
         os.environ["SG_PERSIST_IN_RDONLY"] = str(val)
 
+
     def ack_unit_attention(self, d):
         if not os.path.exists(d):
             return 0
+        if self.use_mpathpersist(d):
+            return 0
         i = self.preempt_timeout
         self.set_read_only(0)
-        while i>0:
+        while i > 0:
             i -= 1
-            cmd = [ 'sg_persist', '-n', '-r', d ]
+            cmd = ["sg_persist", "-n", "-r", d]
             p = Popen(cmd, stdout=PIPE, stderr=PIPE, close_fds=True)
             out, err = p.communicate()
             out = bdecode(out)
@@ -54,6 +58,16 @@ class ScsiReserv(resScsiReserv.ScsiReserv):
             return 1
         return 0
 
+
+    def read_mpath_registrations(self, disk):
+        if not os.path.exists(disk):
+            return 1, "", ""
+        self.set_read_only(1)
+        cmd = ["mpathpersist", "-i", "-k", disk]
+        ret, out, err = self.call(cmd)
+        return ret, out, err
+
+
     def read_path_registrations(self, disk):
         if not os.path.exists(disk):
             return 1, "", ""
@@ -62,29 +76,36 @@ class ScsiReserv(resScsiReserv.ScsiReserv):
         ret, out, err = self.call(cmd)
         return ret, out, err
 
+
     def read_registrations(self):
-        n_devs = 0
+        n_paths = 0
         n_registered = 0
-        for sub_dev in self.peer_sub_devs:
-            devs = self.mangle_devs([sub_dev])
-            for dev in devs:
-                ret, out, err = self.read_path_registrations(dev)
-                if ret != 0:
-                    continue
-                n_devs += len(devs)
+        for mpath, paths in self.devs.items():
+            if self.use_mpathpersist(mpath):
+                ret, out, err = self.read_mpath_registrations(mpath)
+                n_paths += len(paths)
                 n_registered += out.count(self.hostid)
-                break
-        return n_devs, n_registered
+            else:
+                for path in paths:
+                    ret, out, err = self.read_path_registrations(path)
+                    if ret != 0:
+                        continue
+                    n_paths += len(paths)
+                    n_registered += out.count(self.hostid)
+                    break
+        return n_paths, n_registered
+
 
     def check_all_paths_registered(self):
-        n_devs, n_registered = self.read_registrations()
-        if n_registered == n_devs:
+        n_paths, n_registered = self.read_registrations()
+        if n_registered == n_paths:
             return
         if n_registered == 0:
             return
-        if n_registered > n_devs:
-            raise ex.excSignal("%d/%d paths registered" % (n_registered, n_devs))
-        raise ex.excError("%d/%d paths registered" % (n_registered, n_devs))
+        if n_registered > n_paths:
+            raise ex.excSignal("%d/%d paths registered" % (n_registered, n_paths))
+        raise ex.excError("%d/%d paths registered" % (n_registered, n_paths))
+
 
     def disk_registered(self, disk):
         ret, out, err = self.read_path_registrations(disk)
@@ -94,35 +115,78 @@ class ScsiReserv(resScsiReserv.ScsiReserv):
             return True
         return False
 
-    def mpath_register(self, disk):
-        self.set_read_only(0)
-        cmd = [ 'mpathpersist', '--out', '--register-ignore', '--param-sark='+self.hostid, disk ]
-        (ret, out, err) = self.vcall(cmd)
-        if ret != 0:
-            self.log.error("failed to register key %s with disk %s" % (self.hostid, disk))
-        return ret
+
+    @lazy
+    def has_mpathpersist(self):
+        return which("mpathpersist")
+
+
+    def use_mpathpersist(self, disk):
+        if not self.has_mpathpersist:
+            return False
+        if [disk] != self.devs[disk]:
+            return True
+        return False
+
 
     def disk_register(self, disk):
+        if self.use_mpathpersist(disk):
+            return self.mpath_register(disk)
+        else:
+            ret = 0
+            for path in self.devs[disk]:
+                ret += self.path_register(path)
+            return ret
+
+
+    def mpath_register(self, disk):
         self.set_read_only(0)
-        cmd = [ 'sg_persist', '-n', '--out', '--register-ignore', '--param-sark='+self.hostid, disk ]
-        (ret, out, err) = self.vcall(cmd)
+        cmd = ["mpathpersist", "--out", "--register-ignore", "--param-sark="+self.hostid, disk]
+        ret, out, err = self.vcall(cmd)
         if ret != 0:
             self.log.error("failed to register key %s with disk %s" % (self.hostid, disk))
         return ret
 
-    def disk_unregister(self, disk):
+
+    def path_register(self, disk):
         self.set_read_only(0)
-        cmd = [ 'sg_persist', '-n', '--out', '--register-ignore', '--param-rk='+self.hostid, disk ]
-        (ret, out, err) = self.vcall(cmd)
+        cmd = ["sg_persist", "-n", "--out", "--register-ignore", "--param-sark="+self.hostid, disk]
+        ret, out, err = self.vcall(cmd)
+        if ret != 0:
+            self.log.error("failed to register key %s with disk %s" % (self.hostid, disk))
+        return ret
+
+
+    def disk_unregister(self, disk):
+        if self.use_mpathpersist(disk):
+            return self.mpath_unregister(disk)
+        else:
+            return self.path_unregister(disk)
+
+
+    def mpath_unregister(self, disk):
+        self.set_read_only(0)
+        cmd = ["mpathpersist", "--out", "--register-ignore", "--param-rk="+self.hostid, disk]
+        ret, out, err = self.vcall(cmd)
         if ret != 0:
             self.log.error("failed to unregister key %s with disk %s" % (self.hostid, disk))
         return ret
+
+
+    def path_unregister(self, disk):
+        self.set_read_only(0)
+        cmd = ["sg_persist", "-n", "--out", "--register-ignore", "--param-rk="+self.hostid, disk]
+        ret, out, err = self.vcall(cmd)
+        if ret != 0:
+            self.log.error("failed to unregister key %s with disk %s" % (self.hostid, disk))
+        return ret
+
 
     def dev_to_mpath_dev(self, devpath):
         if which(rcEnv.syspaths.multipath) is None:
             return devpath
         cmd = [rcEnv.syspaths.multipath, "-l", "-v1", devpath]
-        (ret, out, err) = self.call(cmd)
+        ret, out, err = self.call(cmd)
         if ret != 0:
             raise ex.excError(err)
         _devpath = "/dev/mapper/"+out.strip()
@@ -132,6 +196,7 @@ class ScsiReserv(resScsiReserv.ScsiReserv):
             raise ex.excError("%s does not exist" % _devpath)
         return _devpath
 
+
     def get_reservation_key(self, disk):
         try:
             return self._get_reservation_key(disk)
@@ -139,18 +204,28 @@ class ScsiReserv(resScsiReserv.ScsiReserv):
             disk = self.dev_to_mpath_dev(disk)
             return self._get_reservation_key(disk)
 
+
     def _get_reservation_key(self, disk):
         self.set_read_only(1)
-        cmd = [ 'sg_persist', '-n', '-r', disk ]
-        (ret, out, err) = self.call(cmd, errlog=None)
+        if self.use_mpathpersist(disk):
+            cmd = ["mpathpersist", "-i", "-r", disk]
+        else:
+            cmd = ["sg_persist", "-n", "-r", disk]
+        ret, out, err = self.call(cmd, errlog=None)
         if ret != 0:
             raise ex.excError("failed to list reservation for disk %s" % disk)
-        if 'Key=' not in out:
+        if "Key=" in out:
+            # sg_persist format
+            for w in out.split():
+                if "Key=" in w:
+                    return w.split("=")[1]
+        elif "Key = " in out:
+            # mpathpersist format
+            return out.split("Key = ")[-1].split()[0]
+        else:
             return None
-        for w in out.split():
-            if 'Key=' in w:
-                return w.split('=')[1]
         raise Exception()
+
 
     def disk_reserved(self, disk):
         try:
@@ -159,49 +234,106 @@ class ScsiReserv(resScsiReserv.ScsiReserv):
             disk = self.dev_to_mpath_dev(disk)
             return self._disk_reserved(disk)
 
+
     def _disk_reserved(self, disk):
         self.set_read_only(1)
-        cmd = [ 'sg_persist', '-n', '-r', disk ]
-        (ret, out, err) = self.call(cmd)
+        if self.use_mpathpersist(disk):
+            cmd = ["mpathpersist", "-i", "-r", disk]
+        else:
+            cmd = ["sg_persist", "-n", "-r", disk]
+        ret, out, err = self.call(cmd)
         if ret != 0:
             raise ex.excError("failed to read reservation for disk %s" % disk)
         if self.hostid in out:
             return True
         return False
 
+
     def disk_release(self, disk):
+        if self.use_mpathpersist(disk):
+            return self.mpath_release(disk)
+        else:
+            return self.path_release(disk)
+
+
+    def mpath_release(self, disk):
         self.set_read_only(0)
-        cmd = [ 'sg_persist', '-n', '--out', '--release', '--param-rk='+self.hostid, '--prout-type='+self.prtype, disk ]
-        (ret, out, err) = self.vcall(cmd)
+        cmd = ["mpathpersist", "--out", "--release", "--param-rk="+self.hostid, "--prout-type="+self.prtype, disk]
+        ret, out, err = self.vcall(cmd)
         if ret != 0:
             self.log.error("failed to release disk %s" % disk)
         return ret
 
+
+    def path_release(self, disk):
+        self.set_read_only(0)
+        cmd = ["sg_persist", "-n", "--out", "--release", "--param-rk="+self.hostid, "--prout-type="+self.prtype, disk]
+        ret, out, err = self.vcall(cmd)
+        if ret != 0:
+            self.log.error("failed to release disk %s" % disk)
+        return ret
+
+
     def disk_clear_reservation(self, disk):
-        cmd = [ 'sg_persist', '-n', '--out', '--clear', '--param-rk='+self.hostid, disk ]
-        (ret, out, err) = self.vcall(cmd)
+        if self.use_mpathpersist(disk):
+            return self.mpath_clear_reservation(disk)
+        else:
+            return self.path_clear_reservation(disk)
+
+
+    def mpath_clear_reservation(self, disk):
+        cmd = ["mpathpersist", "--out", "--clear", "--param-rk="+self.hostid, disk]
+        ret, out, err = self.vcall(cmd)
         if ret != 0:
             self.log.error("failed to clear reservation on disk %s" % disk)
         return ret
 
+
+    def path_clear_reservation(self, disk):
+        cmd = ["sg_persist", "-n", "--out", "--clear", "--param-rk="+self.hostid, disk]
+        ret, out, err = self.vcall(cmd)
+        if ret != 0:
+            self.log.error("failed to clear reservation on disk %s" % disk)
+        return ret
+
+
     def disk_reserve(self, disk):
+        if self.use_mpathpersist(disk):
+            return self.mpath_reserve(disk)
+        else:
+            return self.path_reserve(disk)
+
+
+    def mpath_reserve(self, disk):
         self.set_read_only(0)
-        cmd = [ 'sg_persist', '-n', '--out', '--reserve', '--param-rk='+self.hostid, '--prout-type='+self.prtype, disk ]
-        (ret, out, err) = self.vcall(cmd)
+        cmd = ["mpathpersist", "--out", "--reserve", "--param-rk="+self.hostid, "--prout-type="+self.prtype, disk]
+        ret, out, err = self.vcall(cmd)
         if ret != 0:
             self.log.error("failed to reserve disk %s" % disk)
         return ret
 
+
+    def path_reserve(self, disk):
+        self.set_read_only(0)
+        cmd = ["sg_persist", "-n", "--out", "--reserve", "--param-rk="+self.hostid, "--prout-type="+self.prtype, disk]
+        ret, out, err = self.vcall(cmd)
+        if ret != 0:
+            self.log.error("failed to reserve disk %s" % disk)
+        return ret
+
+
     def _disk_preempt_reservation(self, disk, oldkey):
         m = __import__("rcDiskInfo"+rcEnv.sysname)
         if self.no_preempt_abort or m.diskInfo(deferred=True).disk_vendor(disk).strip() in ["VMware"]:
-            preempt_opt = '--preempt'
+            preempt_opt = "--preempt"
         else:
-            preempt_opt = '--preempt-abort'
+            preempt_opt = "--preempt-abort"
         self.set_read_only(0)
-        cmd = [ 'sg_persist', '-n', '--out', preempt_opt, '--param-sark='+oldkey, '--param-rk='+self.hostid, '--prout-type='+self.prtype, disk ]
-        (ret, out, err) = self.vcall(cmd)
+        if self.use_mpathpersist(disk):
+            cmd = ["mpathpersist", "--out", preempt_opt, "--param-sark="+oldkey, "--param-rk="+self.hostid, "--prout-type="+self.prtype, disk]
+        else:
+            cmd = ["sg_persist", "-n", "--out", preempt_opt, "--param-sark="+oldkey, "--param-rk="+self.hostid, "--prout-type="+self.prtype, disk]
+        ret, out, err = self.vcall(cmd)
         if ret != 0:
             self.log.error("failed to preempt reservation for disk %s" % disk)
         return ret
-


### PR DESCRIPTION
Detect mpathpersist presence and prefer it over sg_persist.

The sg_persist is then no longer necessary, the codebase using mpathpersist
for all commands.

OpenSVC doesnt set the defaut.reservation_key=file in multipath.conf. This
is important to set it to activate the register-path-before-add-to-multipath
feature of multipathd, which prevents ioerrs on registered multipath when
one of the active paths is not registered.

Even if defaut.reservation_key=file is not set, the mpathpersist commands we
execute produce the same registration and reservation as with sg_perist.