### PR TITLE
Allow empty sec and cfg keys value

### DIFF
--- a/lib/cfg.py
+++ b/lib/cfg.py
@@ -29,7 +29,7 @@ class Cfg(DataMixin, BaseSvc):
     def _add_key(self, key, data):
         if not key:
             raise ex.excError("configuration key name can not be empty")
-        if not data:
+        if data is None:
             raise ex.excError("configuration value can not be empty")
         if not is_string(data):
             data = "base64:"+bdecode(base64.urlsafe_b64encode(data))

--- a/lib/data.py
+++ b/lib/data.py
@@ -69,7 +69,7 @@ class DataMixin(object):
     def _add(self, key=None, value_from=None, append=False):
         if key and sys.stdin and value_from in ("-", "/dev/stdin"):
             self.add_stdin(key, append=append)
-        elif key and self.options.value:
+        elif key and self.options.value is not None:
             self.add_key(key, self.options.value, append=append)
         elif value_from and os.path.isdir(value_from):
             self.add_directory(key, value_from, append=append)

--- a/lib/sec.py
+++ b/lib/sec.py
@@ -37,7 +37,7 @@ class Sec(DataMixin, BaseSvc):
     def _add_key(self, key, data):
         if not key:
             raise ex.excError("secret key name can not be empty")
-        if not data:
+        if data is None:
             raise ex.excError("secret value can not be empty")
         data = "crypt:"+base64.urlsafe_b64encode(self.encrypt(data, cluster_name="join", encode=True)).decode()
         self.set_multi(["data.%s=%s" % (key, data)])


### PR DESCRIPTION
It might be valid to expose an empty environment variable to a container.

Also it is frequent to find empty files in a file tree imported in a sec or
cfg. In this case, before this patch, the "om <secpath> add --from <head>"
failed when trying to add the key with empty value, leaving the file tree
partially imported.