### PR TITLE
Add the "sc" metadata to objects log lines

### DIFF
--- a/lib/rcLogger.py
+++ b/lib/rcLogger.py
@@ -73,6 +73,7 @@ class OsvcFormatter(logging.Formatter):
             ("path", "o"),
             ("subset", "rs"),
             ("rid", "r"),
+            ("cron", "sc"),
         ]
 
     def format(self, record):
@@ -83,8 +84,13 @@ class OsvcFormatter(logging.Formatter):
                 continue
             try:
                 val = getattr(record, xattr)
-                if val:
-                    record.context += "%s:%s " % (key, getattr(record, xattr))
+                if val in (None, ""):
+                    continue
+                if val is True:
+                    val = "y"
+                elif val is False:
+                    val = "n"
+                record.context += "%s:%s " % (key, val)
             except AttributeError:
                 pass
         record.context = record.context.rstrip()

--- a/lib/resources.py
+++ b/lib/resources.py
@@ -92,7 +92,14 @@ class Resource(object):
         """
         Lazy init for the resource logger.
         """
-        extra = {"path": self.svc.path, "node": rcEnv.nodename, "sid": rcEnv.session_uuid, "rid": self.rid, "subset": self.subset}
+        extra = {
+            "path": self.svc.path,
+            "node": rcEnv.nodename,
+            "sid": rcEnv.session_uuid,
+            "cron": self.svc.options.cron,
+            "rid": self.rid,
+            "subset": self.subset,
+        }
         return logging.LoggerAdapter(logging.getLogger(self.log_label()), extra)
 
     @lazy

--- a/lib/resourceset.py
+++ b/lib/resourceset.py
@@ -377,7 +377,13 @@ class ResourceSet(object):
 
     @lazy
     def log(self):
-        extra = {"path": self.svc.path, "node": rcEnv.nodename, "sid": rcEnv.session_uuid, "subset": self.rid}
+        extra = {
+            "path": self.svc.path,
+            "node": rcEnv.nodename,
+            "sid": rcEnv.session_uuid,
+            "cron": self.svc.options.cron,
+            "subset": self.rid,
+        }
         return logging.LoggerAdapter(self.logger, extra)
 
     @lazy

--- a/lib/svc.py
+++ b/lib/svc.py
@@ -617,7 +617,12 @@ class BaseSvc(Crypt, ExtConfigMixin):
 
     @lazy
     def log(self): # pylint: disable=method-hidden
-        extra = {"path": self.path, "node": rcEnv.nodename, "sid": rcEnv.session_uuid}
+        extra = {
+            "path": self.path,
+            "node": rcEnv.nodename,
+            "sid": rcEnv.session_uuid,
+            "cron": self.options.cron,
+        }
         return logging.LoggerAdapter(self.logger, extra)
 
     @lazy


### PR DESCRIPTION
Object actions run by the scheduler set "sc:y", normal actions set "sc:n".
So log viewers can easily filter out scheduled action logs, to focus on
manual and orchestrated actions.