### PR TITLE
Fix a py 3.8 warning

### DIFF
--- a/lib/rcOptParser.py
+++ b/lib/rcOptParser.py
@@ -309,7 +309,7 @@ class OptParser(object):
         interpreted as an action. Raise if not, else return the action name
         formatted as a '_' joined string.
         """
-        if len(args) is 0:
+        if len(args) == 0:
             if options.parm_help:
                 self.print_full_help()
             else:


### PR DESCRIPTION
/opt/opensvc/lib/rcOptParser.py:312: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(args) is 0: