### PR TITLE
Fix "om <sec> edit --key ..." on py3 for keys injected from file

### DIFF
--- a/lib/data.py
+++ b/lib/data.py
@@ -125,9 +125,12 @@ class DataMixin(object):
             self.edit_config()
             return
         buff = self.decode_key(self.options.key)
-        no_newline = buff.count(os.linesep) == 0
         if buff is None:
             raise ex.excError("could not decode the secret key '%s'" % self.options.key)
+        try:
+            no_newline = os.sep not in buff.decode()
+        except Exception:
+            raise ex.excError("this key is not editable")
         editor = find_editor()
         fpath = self.tempfilename()
         try:


### PR DESCRIPTION
These keys decode() return binary data, so we need to decode() the read buffer
before searching linesep into it.

If we can't decode, raise an informative error stating the key is not editable:
no need to display a binary in a text editor.