### PR TITLE
Support volume path translation in app resource keywords

### DIFF
--- a/lib/rcUtilities.py
+++ b/lib/rcUtilities.py
@@ -1664,7 +1664,7 @@ def create_protected_file(filepath, buff):
         f.write(buff)
 
     if six.PY2:
-        if isinstance(buff, unicode):
+        if isinstance(buff, six.text_type):
             import codecs
             with codecs.open(filepath, "w", "utf-8") as f:
                 onfile(f)

--- a/lib/resApp.py
+++ b/lib/resApp.py
@@ -318,7 +318,9 @@ class App(Resource):
                 else:
                     cmd = shlex.split(val)
                 if "|" in cmd or "||" in cmd or "&&" in cmd or any([True for w in cmd if w.endswith(";")]):
+                    val, vol = self.replace_volname(val, strict=False, errors="ignore")
                     return val
+        cmd[0], vol = self.replace_volname(cmd[0], strict=False, errors="ignore")
         if validate:
             cmd = self.validate_on_action(cmd)
         return cmd


### PR DESCRIPTION
So app resources scripts can be delivered as cfg or sec keys.
Their environment variables could already be stored in cfg or sec.

Keywords:
* script
* start
* stop
* status
* info

Example (access=rwx because its a flex svc, up on all node):

[volume#1]
type = shm
perm = 755
name = {name}
size = 1m
access = rwx
configs = {name}/foo.sh:/

[app#1]
configs_environment = FOO={name}/foo
script = {name}/foo.sh
start = true
stop = true
check = true