### PR TITLE
Add /usr/lib/cni to the candidate path for CNI binaries

### DIFF
--- a/lib/provFsFlagLinux.py
+++ b/lib/provFsFlagLinux.py
@@ -5,5 +5,14 @@ class Prov(provisioning.Prov):
         provisioning.Prov.__init__(self, r)
     
     def is_provisioned(self):
-        return True
+        flag = self.r.is_provisioned_flag()
+        if flag is None:
+            return False
+        return flag
+
+    def provisioner(self):
+        pass
+
+    def unprovisioner(self):
+        pass
 

--- a/lib/resFsFlagAbstract.py
+++ b/lib/resFsFlagAbstract.py
@@ -68,15 +68,3 @@ class Fs(resources.Resource):
             self.log.exception(exc)
             return True
 
-    def provisioned(self):
-        flag = self.is_provisioned_flag()
-        if flag is None:
-            return False
-        return flag
-
-    def provisioner(self):
-        pass
-
-    def unprovisioner(self):
-        pass
-

--- a/lib/resIpCni.py
+++ b/lib/resIpCni.py
@@ -165,6 +165,9 @@ class Ip(Res.Ip):
         path = self.svc.node.oget("cni", "plugins")
         if os.path.exists(os.path.join(path, "bridge")):
             return path
+        altpath = os.path.join(os.sep, "usr", "lib", "cni")
+        if os.path.exists(os.path.join(altpath, "bridge")):
+            return altpath
         altpath = os.path.join(os.sep, "usr", "libexec", "cni")
         if os.path.exists(os.path.join(altpath, "bridge")):
             return altpath


### PR DESCRIPTION
As ubuntu 20.04 containernetworking-plugins package now installs them there.