### PR TITLE
Allow user-defined system/svc/vip ip#0.tags to persist

### DIFF
--- a/lib/osvcd_shared.py
+++ b/lib/osvcd_shared.py
@@ -1510,6 +1510,9 @@ class OsvcThread(threading.Thread, Crypt):
                 changes.append("%s.%s=%s" % (section, keyword, value))
         extraneous = []
         for kw in svc.print_config_data().get("ip#0", {}):
+            if kw == "tags":
+                # never discard tag customization (ex: tags=noaction)
+                continue
             _kw = "ip#0."+kw
             if _kw not in kws:
                 extraneous.append(_kw)


### PR DESCRIPTION
For example, we want to persist the ip#0 "noaction" tag when the vip is an ip
address managed by the operating system.