### PR TITLE
Add a configured key to each daemon thread status dataset

### DIFF
--- a/lib/osvcd_shared.py
+++ b/lib/osvcd_shared.py
@@ -260,6 +260,7 @@ class OsvcThread(threading.Thread, Crypt):
         self._stop_event = threading.Event()
         self._node_conf_event = threading.Event()
         self.created = time.time()
+        self.configured = self.created
         self.threads = []
         self.procs = []
         self.tid = None
@@ -337,6 +338,7 @@ class OsvcThread(threading.Thread, Crypt):
         data = {
             "state": state,
             "created": self.created,
+            "configured": self.configured,
         }
         if self.alerts:
             data["alerts"] = self.alerts
@@ -502,12 +504,14 @@ class OsvcThread(threading.Thread, Crypt):
         self.arbitrators_data = None
         self.alerts = []
         if not hasattr(self, "reconfigure"):
+            self.configured = time.time()
             return
         try:
             getattr(self, "reconfigure")()
         except Exception as exc:
             self.log.error("reconfigure error: %s", str(exc))
             self.stop()
+        self.configured = time.time()
 
     @staticmethod
     def get_service(path):


### PR DESCRIPTION
This new key holds the timestamp of the last OsvcThread::reload_config()
succesful execution.

So it can be used to wait for a change to be honored to continue a batch.
For example:

$ om cluster set --kw env.foo=bar ; \
date ; \
om node wait --filter "monitor.configured>$(om cluster print config mtime)" ; \
date
mer. 20 mai 2020 12:28:23 CEST
mer. 20 mai 2020 12:28:29 CEST

This patch is a backport of 41bfde13f0f1a90a667deb4ff08682d54b7e9fcd.