### PR TITLE
Fix app.simple stop when the script is not accessible (Solaris Only)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 env:
-  - OPENSVC_CI_EXTRA_TIME_OSVCD_STARTUP=20
+  - OPENSVC_CI_EXTRA_TIME_OSVCD_STARTUP=25
 sudo: true
 language: python
 cache: pip

--- a/opensvc/drivers/resource/app/simple/sunos.py
+++ b/opensvc/drivers/resource/app/simple/sunos.py
@@ -13,7 +13,7 @@ class AppSimple(ParentAppSimple):
     The simple App resource driver class.
     """
     def get_running(self, with_children=False):
-        cmd = ["pgrep", "-f", " ".join(self.get_cmd("start"))]
+        cmd = ["pgrep", "-f", " ".join(self.get_cmd("start", validate=False))]
         out, err, ret = justcall(cmd)
         if ret != 0:
             return []


### PR DESCRIPTION
commit 5f88e217436dfb0c919d4ba2853a5abed578ca45 already fix default implementation
with following commit message:
  Add a validate=True|False to get_cmd(), so app.simple can set validate=False
  in the get_matching codepath and not be disrupted when the referenced script
  is not accessible (the holding fs resource might be down).