### PR TITLE
Backport fix app.simple stop when the script is not accessible (Solar…

### DIFF
--- a/lib/resAppSimpleSunOS.py
+++ b/lib/resAppSimpleSunOS.py
@@ -21,7 +21,7 @@ class App(resAppSimple.App):
         resAppSimple.App.__init__(self, rid, **kwargs)
 
     def get_running(self, with_children=False):
-        cmd = ["pgrep", "-f", " ".join(self.get_cmd("start"))]
+        cmd = ["pgrep", "-f", " ".join(self.get_cmd("start", validate=False))]
         out, err, ret = justcall(cmd)
         if ret != 0:
             return []


### PR DESCRIPTION
…is Only)

commit 5f88e21 already fix default implementation
with following commit message:
  Add a validate=True|False to get_cmd(), so app.simple can set validate=False
  in the get_matching codepath and not be disrupted when the referenced script
  is not accessible (the holding fs resource might be down).