### PR TITLE
Fix objects instances in n/a availstatus lingering global_expect

### DIFF
--- a/lib/osvcd_mon.py
+++ b/lib/osvcd_mon.py
@@ -562,6 +562,7 @@ class Monitor(shared.OsvcThread):
         self.set_smon(svc.path, "unprovisioning")
         if leader is None:
             candidates = self.placement_candidates(svc, discard_frozen=False,
+                                                   discard_na=False,
                                                    discard_overloaded=False,
                                                    discard_unprovisioned=False,
                                                    discard_constraints_violation=False)
@@ -597,6 +598,7 @@ class Monitor(shared.OsvcThread):
     def service_provision(self, svc):
         self.set_smon(svc.path, "provisioning")
         candidates = self.placement_candidates(svc, discard_frozen=False,
+                                               discard_na=False,
                                                discard_overloaded=False,
                                                discard_unprovisioned=False,
                                                discard_constraints_violation=False)
@@ -618,6 +620,7 @@ class Monitor(shared.OsvcThread):
         self.set_smon(svc.path, "unprovisioning", local_expect="unset")
         if leader is None:
             candidates = self.placement_candidates(svc, discard_frozen=False,
+                                                   discard_na=False,
                                                    discard_overloaded=False,
                                                    discard_unprovisioned=False,
                                                    discard_constraints_violation=False)
@@ -3091,7 +3094,7 @@ class Monitor(shared.OsvcThread):
             if frozen != "thawed":
                 return
             if shared.AGG[path].placement in ("optimal", "n/a") and \
-               shared.AGG[path].avail == "up":
+               shared.AGG[path].avail in ("up", "n/a"):
                 self.set_smon(path, global_expect="unset")
                 return
             svc = self.get_service(path)
@@ -3402,8 +3405,12 @@ class Monitor(shared.OsvcThread):
             else:
                 return False
         elif global_expect == "shutdown":
+            if instance["avail"] == "n/a":
+                return False
             return not self.get_agg_shutdown(path)
         elif global_expect == "started":
+            if instance["avail"] == "n/a":
+                return False
             if smon.placement == "none":
                 return False
             local_frozen = instance.get("frozen", 0)
@@ -3457,6 +3464,8 @@ class Monitor(shared.OsvcThread):
             else:
                 return False
         elif global_expect == "placed":
+            if instance["avail"] == "n/a":
+                return False
             if smon.placement == "none":
                 return False
             if agg.placement == "non-optimal" or agg.avail != "up" or agg.frozen == "frozen":
@@ -3472,6 +3481,8 @@ class Monitor(shared.OsvcThread):
             else:
                 return False
         elif global_expect.startswith("placed@"):
+            if instance["avail"] == "n/a":
+                return False
             target = global_expect.split("@")[-1].split(",")
             if rcEnv.nodename in target:
                 if instance["avail"] in STOPPED_STATES:


### PR DESCRIPTION
* do not accept from peers a stop/start/shutdown/placed* global expect on an
instance in n/a availstatus, as we can not reach the state.

* reset the stop/start/shutdown/placed* global expect for instances in n/a
availstatus. It might have been set before the instance goes n/a or set via
api for propagation to other nodes.