### PR TITLE
Update diag message when 'print config --eval' has errors

### DIFF
--- a/opensvc/core/extconfig.py
+++ b/opensvc/core/extconfig.py
@@ -1444,7 +1444,7 @@ class ExtConfigMixin(object):
                 except (ex.RequiredOptNotFound, ex.OptNotFound):
                     continue
                 except ValueError:
-                    pass
+                    raise
                 # ensure the data is json-exportable
                 if isinstance(val, set):
                     val = list(val)


### PR DESCRIPTION

Before: {"error": "local variable 'val' referenced before assignment"}
Now:    {"error": "DEFAULT.start_timeout not found in the keywords dictionary"}