### PR TITLE
backport update diag message when 'print config --eval' fails because of confi…

### DIFF
--- a/lib/extconfig.py
+++ b/lib/extconfig.py
@@ -1270,7 +1270,7 @@ class ExtConfigMixin(object):
                 except (ex.RequiredOptNotFound, ex.OptNotFound):
                     continue
                 except ValueError:
-                    pass
+                    raise
                 # ensure the data is json-exportable
                 if isinstance(val, set):
                     val = list(val)


### PR DESCRIPTION
…g errors

Before: {"error": "local variable 'val' referenced before assignment"}
Now:    {"error": "DEFAULT.start_timeout not found in the keywords dictionary"}