### PR TITLE
Fix ignored tasks "on_error" trigger

### DIFF
--- a/lib/rcUtilities.py
+++ b/lib/rcUtilities.py
@@ -679,6 +679,7 @@ def action_triggers(self, trigger="", action=None, **kwargs):
         'sync_update',
         'sync_restore',
         'run',
+        'on_error', # tasks use that as an action
         'command',  # tasks use that as an action
     ]
 


### PR DESCRIPTION
The action trigger did not accept the "on_error" trigger name
used by the task.host driver.