### PR TITLE
[drivers.resource.ip.host] Fix netmask value for Solaris

### DIFF
--- a/opensvc/drivers/resource/ip/__init__.py
+++ b/opensvc/drivers/resource/ip/__init__.py
@@ -587,17 +587,10 @@ class Ip(Resource):
         """
         The start codepath fragment protected by the startip lock.
         """
-        ifconfig = self.get_ifconfig()
-        self.get_mask(ifconfig)
-        if 'noalias' in self.tags:
-            self.stacked_dev = self.ipdev
-        else:
-            self.stacked_dev = ifconfig.get_stacked_dev(self.ipdev,\
-                                                        self.addr,\
-                                                        self.log)
+        self.get_stack_dev()
         if self.stacked_dev is None:
             raise ex.Error("could not determine a stacked dev for parent "
-                              "interface %s" % self.ipdev)
+                           "interface %s" % self.ipdev)
 
         arp_announce = True
         try:
@@ -612,6 +605,16 @@ class Ip(Resource):
             raise ex.Error("failed")
 
         return arp_announce
+
+    def get_stack_dev(self):
+        ifconfig = self.get_ifconfig()
+        self.get_mask(ifconfig)
+        if 'noalias' in self.tags:
+            self.stacked_dev = self.ipdev
+        else:
+            self.stacked_dev = ifconfig.get_stacked_dev(self.ipdev,
+                                                        self.addr,
+                                                        self.log)
 
     def dns_update(self):
         """

--- a/opensvc/drivers/resource/ip/host/sunos.py
+++ b/opensvc/drivers/resource/ip/host/sunos.py
@@ -1,4 +1,5 @@
 import utilities.ping
+from utilities.net.converters import cidr_to_dotted, hexmask_to_dotted
 
 from .. import Ip
 
@@ -24,7 +25,7 @@ class IpHost(Ip):
         cmd = [
             "/usr/sbin/ifconfig", self.stacked_dev,
             "plumb", self.addr,
-            "netmask", "+", "broadcast", "+", "up",
+            "netmask", hexmask_to_dotted(self.netmask), "broadcast", "+", "up",
         ]
         return self.vcall(cmd)
 

--- a/opensvc/tests/resource/ip/test_ip_host_sunos.py
+++ b/opensvc/tests/resource/ip/test_ip_host_sunos.py
@@ -1,0 +1,53 @@
+import pytest
+
+from utilities.drivers import driver_import, driver_class
+
+IFCONFIG = """lo0: flags=2001000849<UP,LOOPBACK,RUNNING,MULTICAST,IPv4,VIRTUAL> mtu 8232 index 1
+\tinet 127.0.0.1 netmask ff000000
+net0: flags=100001004843<UP,BROADCAST,RUNNING,MULTICAST,DHCP,IPv4,PHYSRUNNING> mtu 1500 index 2
+\tinet 10.0.2.10 netmask ffffff00 broadcast 10.0.2.255
+\tether 2:8:20:b2:e8:3a
+net1: flags=100001000843<UP,BROADCAST,RUNNING,MULTICAST,IPv4,PHYSRUNNING> mtu 1500 index 2
+\tinet 10.22.0.11 netmask ffff0000 broadcast 10.0.255.255
+\tether 2:8:20:b2:e8:3b
+net2: flags=100001000843<UP,BROADCAST,RUNNING,MULTICAST,IPv4,PHYSRUNNING> mtu 1500 index 2
+\tinet 10.22.0.12 netmask ff000000 broadcast 10.0.2.255
+\tether 2:8:20:b2:e8:3c
+"""
+
+
+@pytest.fixture(scope='function')
+def ip_class(mocker, mock_sysname):
+    mock_sysname('SunOS')
+    klass = driver_class(driver_import('resource', 'ip', 'Host'))
+    from utilities.ifconfig.sunos import Ifconfig
+    ifconfig = Ifconfig(ifconfig=str(IFCONFIG))
+    log = mocker.Mock('log', info=mocker.Mock('info'), debug=mocker.Mock('debug'))
+    mocker.patch.object(klass, 'vcall', mocker.Mock('vcall'))
+    mocker.patch.object(klass, 'log', log)
+    mocker.patch.object(klass, 'get_ifconfig', mocker.Mock('get_ifconfig', return_value=ifconfig))
+    return klass
+
+
+@pytest.mark.ci
+@pytest.mark.usefixtures('osvc_path_tests')
+class TestIpStartCmd:
+    @staticmethod
+    @pytest.mark.parametrize('ipdev,expected_netmask',
+                             [('net0', '255.255.255.0'),
+                              ('net1', '255.255.0.0'),
+                              ('net2', '255.0.0.0'),
+                              ])
+    def test_call_with_correct_netmask(ip_class, ipdev, expected_netmask):
+        ip = ip_class(ipname='192.168.0.149', ipdev=ipdev)
+        ip.addr = ip.ipname
+        ip.get_stack_dev()
+        ip.startip_cmd()
+
+        expected_cmd = ["/usr/sbin/ifconfig", ipdev + ':1',
+                        "plumb", '192.168.0.149',
+                        "netmask", expected_netmask,
+                        "broadcast", "+",
+                        "up",
+        ]
+        ip.vcall.assert_called_once_with(expected_cmd)


### PR DESCRIPTION
Avoid use of ifconfig ... netmask +
Instead use detected netmask value

Reason:
 netmask + use detected net networks in /etc/inet/netmask
 when network is not found in netmask file, ifconfig netmask +
 will set netmask from standard ip classes

 This may lead to start ip with incorrect netmask, and then
 have a service print status that complain about invalid netmask

test_ip_host_sunos.TestIpStartCmd
  o test_call_ifconfig_with_correct_netmask_value[net0-255.255.255.0]
  o test_call_ifconfig_with_correct_netmask_value[net1-255.255.0.0]
  o test_call_ifconfig_with_correct_netmask_value[net2-255.0.0.0]
