### PR TITLE
[drivers.resource.ip.host] Fix regression in netmask value for Solaris

### DIFF
--- a/opensvc/drivers/resource/ip/host/sunos.py
+++ b/opensvc/drivers/resource/ip/host/sunos.py
@@ -1,5 +1,5 @@
 import utilities.ping
-from utilities.net.converters import cidr_to_dotted, hexmask_to_dotted
+from utilities.net.converters import cidr_to_dotted, to_cidr
 
 from .. import Ip
 
@@ -25,11 +25,10 @@ class IpHost(Ip):
         cmd = [
             "/usr/sbin/ifconfig", self.stacked_dev,
             "plumb", self.addr,
-            "netmask", hexmask_to_dotted(self.netmask), "broadcast", "+", "up",
+            "netmask", cidr_to_dotted(to_cidr(self.netmask)), "broadcast", "+", "up",
         ]
         return self.vcall(cmd)
 
     def stopip_cmd(self):
         cmd = ["/usr/sbin/ifconfig", self.stacked_dev, "unplumb"]
         return self.vcall(cmd)
-

--- a/opensvc/tests/resource/ip/test_ip_host_sunos.py
+++ b/opensvc/tests/resource/ip/test_ip_host_sunos.py
@@ -33,13 +33,18 @@ def ip_class(mocker, mock_sysname):
 @pytest.mark.usefixtures('osvc_path_tests')
 class TestIpStartCmd:
     @staticmethod
-    @pytest.mark.parametrize('ipdev,expected_netmask',
-                             [('net0', '255.255.255.0'),
-                              ('net1', '255.255.0.0'),
-                              ('net2', '255.0.0.0'),
+    @pytest.mark.parametrize('ipdev, netmask, expected_netmask',
+                             [('net0', None, '255.255.255.0'),
+                              ('net1', None, '255.255.0.0'),
+                              ('net2', None, '255.0.0.0'),
+                              ('net2', '24', '255.255.255.0'),
+                              ('net2', '8', '255.0.0.0'),
                               ])
-    def test_call_ifconfig_with_correct_netmask_value(ip_class, ipdev, expected_netmask):
-        ip = ip_class(ipname='192.168.0.149', ipdev=ipdev)
+    def test_call_ifconfig_with_correct_netmask_value(ip_class, ipdev, netmask, expected_netmask):
+        kwargs = {'ipname': '192.168.0.149', 'ipdev': ipdev}
+        if netmask:
+            kwargs['netmask'] = netmask
+        ip = ip_class(**kwargs)
         ip.addr = ip.ipname
         ip.get_stack_dev()
         ip.startip_cmd()


### PR DESCRIPTION
It didn't respect anymore respect netmask keyword value from service ip config

The regression was introduce by 4605f672a67e1fef1475ba8870d2e30fc2d5eea1 [drivers.resource.ip.host] Fix netmask value for Solaris)