### PR TITLE
Fix a stack in utilities.version

### DIFF
--- a/opensvc/utilities/version/__init__.py
+++ b/opensvc/utilities/version/__init__.py
@@ -35,7 +35,10 @@ def agent_version():
         out, err, ret = justcall(cmd)
         if ret != 0:
             return "dev"
-        _release = out.strip().split("-")[1]
+        try:
+            _release = out.strip().split("-")[1]
+        except IndexError:
+            _release = out
         return "-".join((_version, _release+"dev"))
 
     return "dev"

--- a/opensvc/utilities/version/__init__.py
+++ b/opensvc/utilities/version/__init__.py
@@ -38,7 +38,7 @@ def agent_version():
         try:
             _release = out.strip().split("-")[1]
         except IndexError:
-            _release = out
+            _release = "0"
         return "-".join((_version, _release+"dev"))
 
     return "dev"


### PR DESCRIPTION
On an install from git, and when a new tag is created on the HEAD, the split
on '-' returns only one element, which causes an IndexError.