### PR TITLE
Fix om node print devs stack when FAULTY zpool exists (Solaris)

### DIFF
--- a/opensvc/utilities/devtree/sunos.py
+++ b/opensvc/utilities/devtree/sunos.py
@@ -210,8 +210,12 @@ class DevTree(DevTreeVeritas, BaseDevTree):
             return
         lines = out.split('\n')
         lines = [l for l in lines if len(l) > 0]
-        self.zpool_used[poolname] = self.read_size(lines[-1].split()[1])
-        zpool_free = self.read_size(lines[-1].split()[2])
+        zpool_iostats = lines[-1].split()
+        if zpool_iostats[0] != poolname:
+            # may be a FAULTY zpool, so no stats
+            return
+        self.zpool_used[poolname] = self.read_size(zpool_iostats[1])
+        zpool_free = self.read_size(zpool_iostats[2])
         self.zpool_size[poolname] = self.zpool_used[poolname] + zpool_free
 
         out, err, ret = justcall(["zfs", "list", "-H", "-r", "-t", "filesystem", poolname])


### PR DESCRIPTION
When pool is FAULTY, we can not extract its dev info

o zpool status faultypool output:
      pool: faultypool
    state: UNAVAIL
    status: One or more devices are unavailable in response to persistent errors.
            There are insufficient replicas for the pool to continue functioning.
    action: Destroy and re-create the pool from a backup source. Manually marking
            the device repaired using 'zpool clear' or 'fmadm repaired' may
            allow some data to be recovered.
            Run 'zpool status -v' to see device specific details.
      scan: none requested
    config:

            NAME                     STATE      READ WRITE CKSUM
            tpool                    UNAVAIL       0     0     0
              mirror-0               UNAVAIL       0     0     0
                /file1               UNAVAIL       0     0     0
                3050059147443554189  UNAVAIL       0     0     0

    errors: No known data errors

o zpool iostat faultypool output:
        capacity     operations    bandwidth
   pool  alloc   free   read  write   read  write
     -----  -----  -----  -----  -----  -----

o stack example:
    om node print dev
    Traceback (most recent call last):
      File "/usr/lib/python3.5/runpy.py", line 193, in _run_module_as_main
        "__main__", mod_spec)
      File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
        exec(code, run_globals)
      File "/usr/share/opensvc/opensvc/__main__.py", line 118, in <module>
        ret = main()
      File "/usr/share/opensvc/opensvc/__main__.py", line 91, in main
        ret = main(argv=sys.argv[2:])
      File "/usr/share/opensvc/opensvc/commands/node/__init__.py", line 65, in main
        return _main(node, argv=argv)
      File "/usr/share/opensvc/opensvc/commands/node/__init__.py", line 45, in _main
        err = node.action(action)
      File "/usr/share/opensvc/opensvc/core/node/node.py", line 1077, in action
        return self._action(action, options)
      File "/usr/share/opensvc/opensvc/core/scheduler.py", line 114, in _func
        ret = func(self, action, options)
      File "/usr/share/opensvc/opensvc/core/node/node.py", line 1104, in _action
        getattr(self, action)()
      File "/usr/share/opensvc/opensvc/core/node/node.py", line 3573, in print_devs
        self.devtree.print_tree(devices=self.options.devices,
      File "/usr/share/opensvc/opensvc/utilities/lazy.py", line 10, in _lazyprop
        setattr(self, attr_name, fn(self))
      File "/usr/share/opensvc/opensvc/core/node/node.py", line 1985, in devtree
        tree.load()
      File "/usr/share/opensvc/opensvc/utilities/devtree/sunos.py", line 304, in load
        self.load_zpool()
      File "/usr/share/opensvc/opensvc/utilities/devtree/sunos.py", line 169, in load_zpool
        self.load_zpool1(poolname)
      File "/usr/share/opensvc/opensvc/utilities/devtree/sunos.py", line 213, in load_zpool1
        self.zpool_used[poolname] = self.read_size(lines[-1].split()[1])
      File "/usr/share/opensvc/opensvc/utilities/devtree/sunos.py", line 280, in read_size
        size = float(s[:-1].replace(',','.'))
    ValueError: could not convert string to float: '----'