### PR TITLE
Fix a stack on provision in disk.drbd when the listener reports unsup…

### DIFF
--- a/opensvc/daemon/listener.py
+++ b/opensvc/daemon/listener.py
@@ -1140,7 +1140,11 @@ class ClientHandler(shared.OsvcThread):
             "options": options,
         }
         data = self.update_data_from_path(data)
-        handler = self.get_handler(method, data["action"])
+        try:
+            handler = self.get_handler(method, data["action"])
+        except ex.HTTP as exc:
+            result = {"status": exc.status, "error": exc.msg}
+            return exc.status, content_type, result
 
         try:
             self.authenticate_client(headers)


### PR DESCRIPTION
…ported handler

This patch makes the listener return a error message in this case, so the drbd
driver now logs:

unable to get current allocations: handler GET resource/disk/drbd/allocations is not supported

Daemon-side stack:

Traceback (most recent call last):
  File "/opt/opensvc/opensvc/daemon/listener.py", line 1288, in handle_h2_client
    self.h2_received(data)
  File "/opt/opensvc/opensvc/daemon/listener.py", line 1255, in h2_received
    self.h2_data_received(event)
  File "/opt/opensvc/opensvc/daemon/listener.py", line 1217, in h2_data_received
    status, content_type, data = self.h2_router(event.stream_id)
  File "/opt/opensvc/opensvc/daemon/listener.py", line 1143, in h2_router
    handler = self.get_handler(method, data["action"])
  File "/opt/opensvc/opensvc/daemon/listener.py", line 1579, in get_handler
    raise ex.HTTP(501, "handler %s %s is not supported" % (method, pathname))
core.exceptions.HTTP: status 501: handler GET resource/disk/drbd/allocations is not supported

Client-side stack:

  File "/opt/opensvc/opensvc/drivers/resource/disk/drbd/__init__.py", line 618, in allocate_drbd
    if idx in self.allocations["minors"]:
  File "/opt/opensvc/opensvc/utilities/lazy.py", line 10, in _lazyprop
    setattr(self, attr_name, fn(self))
  File "/opt/opensvc/opensvc/drivers/resource/disk/drbd/__init__.py", line 703, in allocations
    node=self.svc.node.cluster_nodes,
  File "/opt/opensvc/opensvc/core/comm.py", line 734, in daemon_get
    return self.daemon_request(*args, **kwargs)
  File "/opt/opensvc/opensvc/core/comm.py", line 748, in daemon_request
    return self.h2_daemon_request(*args, sp=sp, **kwargs)
  File "/opt/opensvc/opensvc/core/comm.py", line 807, in h2_daemon_request
    resp = conn.get_response()
  File "/opt/opensvc/opensvc/foreign/hyper/http20/connection.py", line 305, in get_response
    return HTTP20Response(stream.getheaders(), stream)
  File "/opt/opensvc/opensvc/foreign/hyper/http20/stream.py", line 240, in getheaders
    self._recv_cb(stream_id=self.stream_id)
  File "/opt/opensvc/opensvc/foreign/hyper/http20/connection.py", line 791, in _recv_cb
    self._single_read()
  File "/opt/opensvc/opensvc/foreign/hyper/http20/connection.py", line 685, in _single_read
    self._sock.fill()
  File "/opt/opensvc/opensvc/foreign/hyper/common/bufsocket.py", line 169, in fill
    raise ConnectionResetError()
ConnectionResetError