### PR TITLE
[packaging] Fix solaris daemon restart during package relocate operat…

### DIFF
--- a/bin/preinstall
+++ b/bin/preinstall
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$PKG_INSTALL_ROOT" != "/" -a "$PKG_INSTALL_ROOT" != "" ]; then
+  echo "skipped pre-install when PKG_INSTALL_ROOT=$PKG_INSTALL_ROOT"
+  exit 0
+fi
+
 # set OSVC_ROOT_PATH
 test -f /etc/sysconfig/opensvc && . /etc/sysconfig/opensvc
 test -f /etc/default/opensvc && . /etc/default/opensvc

--- a/bin/preuninstall
+++ b/bin/preuninstall
@@ -5,6 +5,10 @@ ARGS=$1
 OSFLAVOR=`uname`
 if [ $OSFLAVOR = 'SunOS' -o $OSFLAVOR = 'FreeBSD' ]
 then
+  if [ "$PKG_INSTALL_ROOT" != "/" -a "$PKG_INSTALL_ROOT" != "" ]; then
+    echo "skipped pre-install when PKG_INSTALL_ROOT=$PKG_INSTALL_ROOT"
+    exit 0
+  fi
 	ARGS=0
 fi
 


### PR DESCRIPTION
…ions

If package in installed on non global zone from a global zone, it stop
daemon on global zone, this is not what we want.

So skip pre-install and pre-remove step when PKG_INSTALL_ROOT is not empty