### PR TITLE
Honor "stop --force" in the drbd driver

### DIFF
--- a/opensvc/drivers/resource/disk/drbd/__init__.py
+++ b/opensvc/drivers/resource/disk/drbd/__init__.py
@@ -412,7 +412,7 @@ class DiskDrbd(Resource):
         if not self.res_defined():
             self.log.info("skip: resource not defined (for this host)")
             return
-        if self.is_standby:
+        if self.is_standby and not self.svc.options.force:
             self.stopstandby()
         else:
             self.drbdadm_down()

--- a/opensvc/drivers/resource/task/__init__.py
+++ b/opensvc/drivers/resource/task/__init__.py
@@ -213,6 +213,8 @@ class BaseTask(Resource):
               "understand its role and effects before confirming the run.")
         try:
             buff = input("Do you really want to run %s (yes/no) > " % self.rid)
+        except RuntimeError:
+            raise ex.Error("run aborted (no stdin)")
         except ex.Signal:
             raise ex.Error("timeout waiting for confirmation")
 


### PR DESCRIPTION
The unprovision orchestration execute a "stop --force" on the up instances
before "unprovision". The drbd driver did not "down" the drbd device, so
the stop on the underlying lv failed.