### PR TITLE
Add a pool "status_schedule" keyword

### DIFF
--- a/opensvc/core/node/nodedict.py
+++ b/opensvc/core/node/nodedict.py
@@ -948,6 +948,11 @@ Arbitrators can be tested using :cmd:`om node ping --node <arbitrator name>`.
     },
     {
         "section": "pool",
+        "keyword": "status_schedule",
+        "text": "The value to set to the status_schedule keyword of the volume objects allocated from the pool. See usr/share/doc/schedule for the schedule syntax."
+    },
+    {
+        "section": "pool",
         "keyword": "mnt_opt",
         "at": True,
         "text": "The mount options of the fs created over the pool devices."

--- a/opensvc/core/pool.py
+++ b/opensvc/core/pool.py
@@ -53,6 +53,10 @@ class BasePool(object):
     def mnt_opt(self):
         return self.oget("mnt_opt")
 
+    @lazy
+    def status_schedule(self):
+        return self.oget("status_schedule")
+
     def mount_point(self, name):
         return os.path.join(os.sep, "srv", name)
 
@@ -77,6 +81,8 @@ class BasePool(object):
             defaults["flex_min"] = 0
         if nodes:
             defaults["nodes"] = nodes
+        if self.status_schedule is not None:
+            defaults["status_schedule"] = self.status_schedule
         data.append(defaults)
         volume._update(data)
         self.disable_sync_internal(volume)


### PR DESCRIPTION
If set, the volume objects created from the pool will have their
DEFAULT.status_schedule set to this value.