### PR TITLE
[travis] Move to focal to avoid pytest error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ matrix:
   include:
   - os: linux
     python: '2.7'
+    dist: focal
   - os: linux
     python: '3.6'
+    dist: focal
 before_install:
   - sudo apt-get update
   - sudo apt-get -y install procps


### PR DESCRIPTION
This should fix following error:
   $ pytest --cov -m "ci"

   Traceback (most recent call last):
     File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pluggy/manager.py", line 267, in load_setuptools_entrypoints
       plugin = ep.load()
     File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2410, in load
       self.require(*args, **kwargs)
     File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2433, in require
       items = working_set.resolve(reqs, env, installer, extras=self.extras)
     File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pkg_resources/__init__.py", line 791, in resolve
       raise VersionConflict(dist, req).with_context(dependent_req)
   pkg_resources.VersionConflict: (pytest 4.3.1 (/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages), Requirement.parse('pytest>=4.6'))