### PR TITLE
Set use-vc in resolv.conf options for containers using backend ipaddr

### DIFF
--- a/opensvc/drivers/resource/container/__init__.py
+++ b/opensvc/drivers/resource/container/__init__.py
@@ -413,6 +413,7 @@ class BaseContainer(Resource):
     def dns_options(self, options):
         ndots_done = False
         edns0_done = False
+        usevc_done = False
         for co, i in enumerate(options):
             try:
                 if co.startswith("ndots:"):
@@ -424,9 +425,13 @@ class BaseContainer(Resource):
                 pass
             if co == "edns0":
                 edns0_done = True
+            elif co == "use-vc":
+                usevc_done = True
         if not ndots_done:
             options.append("ndots:2")
         if not edns0_done:
             options.append("edns0")
+        if not usevc_done:
+            options.append("use-vc")
         return options
 


### PR DESCRIPTION
When the first namespace is not available the glibc udp dns request will
have to wait until timeout*attemps before trying the next nameserver, which
is 10s by default and 1s minimum (timeout:1 attempts:1).

Setting the use-vc option forces a tcp request instead of a udp request.
A tcp request will fail immediately if the nameserver is down.

Note: alpine's musl libc is not affected by this issue as it requests all
defined nameservers and returns the first response. But setting use-vc there
too is ok.