### PR TITLE
Fix a resource info corruption on peer node labels change

### DIFF
--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -3724,7 +3724,7 @@ class Svc(BaseSvc):
             for resource in rset.resources:
                 status = core.status.Status(resource.status(verbose=True))
                 log = resource.status_logs_strlist()
-                info = resource.status_info()
+                info = resource.status_info
                 tags = sorted(list(resource.tags))
                 disable = resource.is_disabled()
                 _data = {

--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -3724,7 +3724,10 @@ class Svc(BaseSvc):
             for resource in rset.resources:
                 status = core.status.Status(resource.status(verbose=True))
                 log = resource.status_logs_strlist()
-                info = resource.status_info
+                if refresh:
+                    info = resource.status_info()
+                else:
+                    info = resource.last_status_info
                 tags = sorted(list(resource.tags))
                 disable = resource.is_disabled()
                 _data = {

--- a/opensvc/core/resource.py
+++ b/opensvc/core/resource.py
@@ -97,6 +97,7 @@ class Resource(object):
         self.driver_group = self.format_driver_group()
         self.driver_basename = self.format_driver_basename()
         self.rset_id = self.format_rset_id()
+        self.last_status_info = {}
 
     def on_add(self):
         """
@@ -651,7 +652,7 @@ class Resource(object):
         self.status_logs = data.get("log", [])
 
         if "info" in data:
-            set_lazy(self, "status_info", data["info"])
+            self.last_status_info = data["info"]
 
         return status
 
@@ -663,7 +664,7 @@ class Resource(object):
             "status": str(core.status.Status(self.rstatus)),
             "label": self.label,
             "log": self.status_logs,
-            "info": self.status_info,
+            "info": self.last_status_info,
         }
         dpath = os.path.dirname(self.fpath_status_last)
         if not os.path.exists(dpath):
@@ -1035,17 +1036,19 @@ class Resource(object):
         """
         return {}
 
-    @lazy
     def status_info(self):
         data = self._status_info()
         if not self.shared:
+            self.last_status_info = data
             return data
         sopts = self.schedule_options()
         if not sopts:
+            self.last_status_info = data
             return data
         data["sched"] = {}
         for saction, sopt in sopts.items():
             data["sched"][saction] = self.schedule_info(sopt)
+        self.last_status_info = data
         return data
 
     def info(self):

--- a/opensvc/core/resource.py
+++ b/opensvc/core/resource.py
@@ -650,6 +650,9 @@ class Resource(object):
 
         self.status_logs = data.get("log", [])
 
+        if "info" in data:
+            set_lazy(self, "status_log", data["info"])
+
         return status
 
     def write_status_last(self):
@@ -660,6 +663,7 @@ class Resource(object):
             "status": str(core.status.Status(self.rstatus)),
             "label": self.label,
             "log": self.status_logs,
+            "info": self.status_info,
         }
         dpath = os.path.dirname(self.fpath_status_last)
         if not os.path.exists(dpath):
@@ -1031,6 +1035,7 @@ class Resource(object):
         """
         return {}
 
+    @lazy
     def status_info(self):
         data = self._status_info()
         if not self.shared:

--- a/opensvc/core/resource.py
+++ b/opensvc/core/resource.py
@@ -651,7 +651,7 @@ class Resource(object):
         self.status_logs = data.get("log", [])
 
         if "info" in data:
-            set_lazy(self, "status_log", data["info"])
+            set_lazy(self, "status_info", data["info"])
 
         return status
 

--- a/opensvc/drivers/resource/ip/__init__.py
+++ b/opensvc/drivers/resource/ip/__init__.py
@@ -183,6 +183,7 @@ class Ip(Resource):
             return
         left = self.wait_dns
         time_max = self._current_time() + left
+        self.status_info()
         self.svc.print_status_data_eval()
         self.log.info("wait address propagation to peers (wait_dns=%s)", print_duration(left))
         path = ".monitor.nodes.'%s'.services.status.'%s'.resources.'%s'.info.ipaddr~[0-9]" % (Env.nodename, self.svc.path, self.rid)


### PR DESCRIPTION
A consequence of this corruption for ip resource, which resource info contains
the ipaddr used in the dns db, the service dns records are dropped until the
next status refresh (may be up to 10m).

On peer node label changes the daemon triggers a refresh=False rewrite of the
services status.json, so all keys depending on labels are updated, but not
reevaluating the resources status. The resource dataset are fetched from the
resource status.last cache, which did not include the "info" key, causing a
loss of information.

This patch add the "info" key to status.last, and restore this cached
information on print_status_data_eval(refresh=False,...).