### PR TITLE
[container.oci] Fix podman location

### DIFF
--- a/opensvc/core/capabilities/__init__.py
+++ b/opensvc/core/capabilities/__init__.py
@@ -29,7 +29,7 @@ class BaseCapabilities(object):
             data.append("node.x.exportfs")
         if which("findfs"):
             data.append("node.x.findfs")
-        if which("/sbin/podman"):
+        if which("/usr/bin/podman"):
             data.append("node.x.podman")
         if which("/sbin/ip"):
             data.append("node.x.ip")


### PR DESCRIPTION
Without this node.x.podman capability is not detected and container.type oci may use docker instead of podman