### PR TITLE
Don't set registry creds option on docker/podman start commands

### DIFF
--- a/opensvc/drivers/resource/container/docker/__init__.py
+++ b/opensvc/drivers/resource/container/docker/__init__.py
@@ -604,10 +604,7 @@ class ContainerDocker(BaseContainer):
                 if self.run_command:
                     cmd += self.run_command
             else:
-                cmd += ["start"]
-                if not self.lib.config_args_position_head:
-                    cmd += self.client_config()
-                cmd += [self.container_id]
+                cmd += ["start", self.container_id]
         elif action == "stop":
             cmd += ["stop", self.container_id]
         elif action == "kill":


### PR DESCRIPTION
Only applicable to pull and run commands.