### PR TITLE
Fix flex_target not updated on node labels change

### DIFF
--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -2283,6 +2283,7 @@ class BaseSvc(Crypt, ExtConfigMixin):
         self.unset_lazy("ordered_peers")
         self.unset_lazy("flex")
         self.unset_lazy("flex_max")
+        self.unset_lazy("flex_target")
 
     def unset_all_lazy(self):
         self.clear_ref_cache()


### PR DESCRIPTION
Missing lazy unset of Svc::flex_target in Svc::unset_conf_lazies(), which
is called on labels change events.