### PR TITLE
Fix listener crash during invalid daemon join call

### DIFF
--- a/opensvc/daemon/shared.py
+++ b/opensvc/daemon/shared.py
@@ -779,6 +779,9 @@ class OsvcThread(threading.Thread, Crypt):
         return proc
 
     def add_cluster_node(self, nodename):
+        if not nodename:
+            self.log.warning('add_cluster_node called with empty nodename')
+            return
         NODE.unset_lazy("cd")
         NODE.unset_lazy("private_cd")
         unset_lazy(self, "cluster_nodes")
@@ -794,6 +797,9 @@ class OsvcThread(threading.Thread, Crypt):
             del svc
 
     def remove_cluster_node(self, nodename):
+        if not nodename:
+            self.log.warning('remove_cluster_node called with empty nodename')
+            return
         NODE.unset_lazy("cd")
         NODE.unset_lazy("private_cd")
         unset_lazy(self, "cluster_nodes")

--- a/opensvc/tests/daemon/test_shared.py
+++ b/opensvc/tests/daemon/test_shared.py
@@ -10,9 +10,10 @@ from env import Env
 
 @pytest.fixture(scope='function')
 @pytest.mark.usefixtures('osvc_path_tests')
-def thr(osvc_path_tests):
+def thr(osvc_path_tests, mocker):
     shared_thr = shared.OsvcThread()
     shared.NODE = Node()
+    shared_thr.log = mocker.MagicMock()
     return shared_thr
 
 
@@ -29,3 +30,19 @@ class TestSharedAddClusterNode:
     def test_update_cluster_nodes(thr):
         thr.add_cluster_node('node3')
         assert Ccfg().cluster_nodes == [Env.nodename, 'node3']
+
+    @staticmethod
+    @pytest.mark.parametrize('nodename', ['', None])
+    def test_log_warning_if_called_with_empty_nodename(thr, nodename):
+        thr.add_cluster_node(nodename)
+        thr.log.warning.assert_called_once_with('add_cluster_node called with empty nodename')
+
+
+@pytest.mark.ci
+@pytest.mark.usefixtures('osvc_path_tests')
+class TestSharedRemoveClusterNode:
+    @staticmethod
+    @pytest.mark.parametrize('nodename', ['', None])
+    def test_log_warning_if_called_with_empty_nodename(thr, nodename):
+        thr.remove_cluster_node(nodename)
+        thr.log.warning.assert_called_once_with('remove_cluster_node called with empty nodename')


### PR DESCRIPTION
Even if add_cluster_node is not anymore called with empty nonename,
we prefer fix possible future invalid calls

stack:
    ERROR n:node-0 c:listener/local | sequence item 1: expected str instance, NoneType found
    Traceback (most recent call last):
    File "/usr/share/opensvc/opensvc/daemon/listener.py", line 1160, in h2_router
    result = self.router(None, data, stream_id=stream_id, handler=handler)
    File "/usr/share/opensvc/opensvc/daemon/listener.py", line 1816, in router
    return handler.action(nodename, action=action, options=options, stream_id=stream_id, thr=self)
    File "/usr/share/opensvc/opensvc/daemon/handlers/join/post.py", line 24, in action
    data = self.join(nodename, thr=thr, **kwargs)
    File "/usr/share/opensvc/opensvc/daemon/handlers/join/post.py", line 34, in join
    thr.add_cluster_node(nodename)
    File "/usr/share/opensvc/opensvc/daemon/shared.py", line 793, in add_cluster_node
    svc.set_multi(["cluster.nodes="+" ".join(nodes)], validation=False)
    TypeError: sequence item 1: expected str instance, NoneType found