### PR TITLE
Fix stack from crm when daemon is not restarting

### DIFF
--- a/opensvc/core/comm.py
+++ b/opensvc/core/comm.py
@@ -799,7 +799,7 @@ class Crypt(object):
                 except AttributeError:
                     errno = None
                 if errno in RETRYABLE and \
-                   (timeout == 0 or elapsed < timeout):
+                   (timeout == 0 or (timeout and elapsed < timeout)):
                     # Resource temporarily unavailable (busy, overflow)
                     # Retry after a delay, if the daemon is still
                     # running and timeout is not exhausted
@@ -848,7 +848,7 @@ class Crypt(object):
                     continue
                 except socket.error as exc:
                     if exc.errno in RETRYABLE and \
-                       (timeout == 0 or elapsed < timeout):
+                       (timeout == 0 or (timeout and elapsed < timeout)):
                         # Resource temporarily unavailable (busy, overflow)
                         # Retry after a delay, if the daemon is still
                         # running and timeout is not exhausted


### PR DESCRIPTION
Stack example:
    E set monitor status failed: '<' not supported between instances of 'int' and 'NoneType'
    Traceback (most recent call last):
      File "/usr/share/opensvc/opensvc/core/comm.py", line 790, in h2_daemon_request
        conn.request(method, path, headers=headers, body=body)
      File "/usr/share/opensvc/opensvc/foreign/hyper/http20/connection.py", line 274, in request
        self.endheaders(message_body=body, final=True, stream_id=stream_id)
      File "/usr/share/opensvc/opensvc/foreign/hyper/http20/connection.py", line 575, in endheaders
        stream.send_headers(headers_only)
      File "/usr/share/opensvc/opensvc/foreign/hyper/http20/stream.py", line 99, in send_headers
        self._send_outstanding_data()
      File "/usr/share/opensvc/opensvc/foreign/hyper/http20/connection.py", line 486, in _send_outstanding_data
        self._send_cb(data, tolerate_peer_gone=tolerate_peer_gone)
      File "/usr/share/opensvc/opensvc/foreign/hyper/http20/connection.py", line 642, in _send_cb
        self._sock.sendall(data)
    BrokenPipeError: [Errno 32] Broken pipe

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/usr/lib/python3.8/runpy.py", line 193, in _run_module_as_main
        return _run_code(code, main_globals, None,
      File "/usr/lib/python3.8/runpy.py", line 86, in _run_code
        exec(code, run_globals)
      File "/usr/share/opensvc/opensvc/__main__.py", line 118, in <module>
        ret = main()
      File "/usr/share/opensvc/opensvc/__main__.py", line 115, in main
        ret = Mgr(selector=arg1)(argv=sys.argv[2:])
      File "/usr/share/opensvc/opensvc/commands/mgr/__init__.py", line 358, in __call__
        ret = self._main(argv=argv)
      File "/usr/share/opensvc/opensvc/commands/mgr/__init__.py", line 331, in _main
        ret = self.do_svcs_action(options, action, argv=argv)
      File "/usr/share/opensvc/opensvc/commands/mgr/__init__.py", line 137, in do_svcs_action
        ret = self.node.do_svcs_action(action, options)
      File "/usr/share/opensvc/opensvc/core/node/node.py", line 2518, in do_svcs_action
        ret = svc.action(action, options)
      File "/usr/share/opensvc/opensvc/core/objects/svc.py", line 872, in action
        ret = self.async_action(action)
      File "/usr/share/opensvc/opensvc/core/objects/svc.py", line 1443, in async_action
        self.daemon_mon_action(action, wait=wait, timeout=timeout)
      File "/usr/share/opensvc/opensvc/core/objects/svc.py", line 1480, in daemon_mon_action
        data = self.set_service_monitor(global_expect=global_expect)
      File "/usr/share/opensvc/opensvc/core/objects/svc.py", line 2009, in set_service_monitor
        data = self.daemon_post(
      File "/usr/share/opensvc/opensvc/core/comm.py", line 741, in daemon_post
        return self.daemon_request(*args, **kwargs)
      File "/usr/share/opensvc/opensvc/core/comm.py", line 751, in daemon_request
        return self.h2_daemon_request(*args, sp=sp, **kwargs)
      File "/usr/share/opensvc/opensvc/core/comm.py", line 802, in h2_daemon_request
        (timeout == 0 or elapsed < timeout):
    TypeError: '<' not supported between instances of 'int' and 'NoneType'