### PR TITLE
Fix 'om node drain --wait' error

### DIFF
--- a/opensvc/core/node/node.py
+++ b/opensvc/core/node/node.py
@@ -4245,7 +4245,7 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
         wait = self.options.wait
         time = self.options.time
         if wait and time:
-            request_timeout = time + DEFAULT_DAEMON_TIMEOUT
+            request_timeout = convert_duration(time) + DEFAULT_DAEMON_TIMEOUT
         elif wait:
             request_timeout = None
         else:


### PR DESCRIPTION
Add missing convert duration for request timeout

This fix following stack:
    Traceback (most recent call last):
      File "/usr/lib/python3.8/runpy.py", line 193, in _run_module_as_main
        return _run_code(code, main_globals, None,
      File "/usr/lib/python3.8/runpy.py", line 86, in _run_code
        exec(code, run_globals)
      File "/usr/share/opensvc/opensvc/__main__.py", line 118, in <module>
        ret = main()
      File "/usr/share/opensvc/opensvc/__main__.py", line 91, in main
        ret = main(argv=sys.argv[2:])
      File "/usr/share/opensvc/opensvc/commands/node/__init__.py", line 65, in main
        return _main(node, argv=argv)
      File "/usr/share/opensvc/opensvc/commands/node/__init__.py", line 45, in _main
        err = node.action(action)
      File "/usr/share/opensvc/opensvc/core/node/node.py", line 1074, in action
        return self._action(action, options)
      File "/usr/share/opensvc/opensvc/core/scheduler.py", line 114, in _func
        ret = func(self, action, options)
      File "/usr/share/opensvc/opensvc/core/node/node.py", line 1104, in _action
        ret = getattr(self, action)()
      File "/usr/share/opensvc/opensvc/core/node/node.py", line 4248, in drain
        request_timeout = time + DEFAULT_DAEMON_TIMEOUT
     TypeError    : can only concatenate str (not "int") to str