### PR TITLE
Fix 'om daemon start' when daemon is already running

### DIFF
--- a/opensvc/commands/daemon/__init__.py
+++ b/opensvc/commands/daemon/__init__.py
@@ -1,10 +1,9 @@
 from __future__ import print_function
 
-import os
 import sys
 
-import utilities.render.color
 import core.exceptions as ex
+import utilities.render.color
 from commands.daemon.parser import DaemonOptParser
 from core.node import Node
 
@@ -18,23 +17,21 @@ def _main(node, argv=None):
 
     node.check_privs(action)
 
-    err = 0
     try:
-        err = node.action("daemon_"+action)
+        return node.action("daemon_"+action)
     except KeyboardInterrupt:
-        sys.stderr.write("Keybord Interrupt\n")
-        err = 1
+        sys.stderr.write("Keyboard Interrupt\n")
+        return 1
     except ex.Error:
         import traceback
         exc_type, exc_value, exc_traceback = sys.exc_info()
         es = str(exc_value)
         if len(es) > 0:
             sys.stderr.write(str(exc_value)+'\n')
-        err = 1
+        return 1
     except:
         raise
-        err = 1
-    return err
+
 
 def main(argv=None):
     node = Node()
@@ -50,7 +47,7 @@ def main(argv=None):
     finally:
         node.close()
 
+
 if __name__ == "__main__":
     ret = main()
     sys.exit(ret)
-

--- a/opensvc/core/node/node.py
+++ b/opensvc/core/node/node.py
@@ -4335,6 +4335,9 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
     def daemon_start(self):
         if self.options.thr_id:
             return self.daemon_start_thread()
+        if self.daemon_running() == 0:
+            self.log.info('daemon is already started')
+            return
         if self.options.foreground:
             return self.daemon_start_foreground()
         return self.daemon_start_native()
@@ -4366,9 +4369,9 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
 
     def daemon_running(self):
         if self._daemon_running():
-            return
+            return 0
         else:
-            raise ex.Error
+            return 1
 
     def _daemon_running(self):
         if self.options.thr_id:

--- a/opensvc/tests/commands/daemon/test_daemon.py
+++ b/opensvc/tests/commands/daemon/test_daemon.py
@@ -92,7 +92,7 @@ name     id                                    requester  requested
 '''
         else:
             expected_output = '''
-name     id                                    requester  requested     
+name     id                                    requester  requested      
 |- plic  01e4491d-083f-48ba-8cdf-c5c8771e6b99  u2004-1    1593425914.04  
 `- ploc  01e4491d-083f-48ba-8cdf-c5c8771e6b92  u2004-1    1593425914.03  
 

--- a/opensvc/tests/commands/daemon/test_daemon.py
+++ b/opensvc/tests/commands/daemon/test_daemon.py
@@ -86,19 +86,19 @@ class TestDaemonLockShow:
         if int(sys.version[0]) > 2:
             expected_output = '''
 name     id                                    requester  requested           
-|- plic  01e4491d-083f-48ba-8cdf-c5c8771e6b92  u2004-1    1593425914.0323133  
-`- ploc  01e4491d-083f-48ba-8cdf-c5c8771e6b99  u2004-1    1593425914.0423133  
+|- plic  01e4491d-083f-48ba-8cdf-c5c8771e6b99  u2004-1    1593425914.0423133  
+`- ploc  01e4491d-083f-48ba-8cdf-c5c8771e6b92  u2004-1    1593425914.0323133  
 
 '''
         else:
             expected_output = '''
 name     id                                    requester  requested     
-|- plic  01e4491d-083f-48ba-8cdf-c5c8771e6b92  u2004-1    1593425914.03  
-`- ploc  01e4491d-083f-48ba-8cdf-c5c8771e6b99  u2004-1    1593425914.04  
+|- plic  01e4491d-083f-48ba-8cdf-c5c8771e6b99  u2004-1    1593425914.04  
+`- ploc  01e4491d-083f-48ba-8cdf-c5c8771e6b92  u2004-1    1593425914.03  
 
 '''
         with open(tmp_file, 'r') as output_file:
-            '\n' + output_file.read() == expected_output
+            assert '\n' + output_file.read() == expected_output
 
     @staticmethod
     def test_output_with_format_json(daemon_get, capture_stdout, tmp_file):


### PR DESCRIPTION
Call 'om daemon start' does restart opensvc daemon if daemon is already running.

Now call 'om daemon start' when daemon is already running simply return without actions.