### PR TITLE
Fix tcp ~15s hangs in containers tcp connections

### DIFF
--- a/opensvc/core/node/linux.py
+++ b/opensvc/core/node/linux.py
@@ -129,6 +129,12 @@ class Node(BaseNode):
             for line in out.splitlines():
                 self.log.info(line)
 
+    def mac_from_ip(self, ip):
+        mac = "0a:58"
+        for i in ip.split("/", 1)[0].split("."):
+            mac += ":%.2x" % int(i)
+        return mac
+
     def network_bridge_add(self, name, ip):
         cmd = ["ip", "link", "show", name]
         _, _, ret = justcall(cmd)
@@ -142,6 +148,10 @@ class Node(BaseNode):
             self.vcall(cmd)
         cmd = ["ip", "link", "show", "dev", name]
         out, _, _ = justcall(cmd)
+        mac = self.mac_from_ip(ip)
+        if mac not in out:
+            cmd = ["ip", "link", "set", "dev", name, "address", self.mac_from_ip(ip)]
+            self.vcall(cmd)
         if "DOWN" in out:
             cmd = ["ip", "link", "set", "dev", name, "up"]
             self.vcall(cmd)


### PR DESCRIPTION
When the device with the lowest mac is removed from the bridge or when
a new device with the lowest mac is added to the bridge, all containers
can experience tcp hangs while the arp table resynchronizes.

Setting a mac address to the bridge explicitely avoids these mac address
changes.

Forge the mac address using a 0a:58 prefix followed by the bridge ipv4
address converted to hexa (same algorithm used in k8s).

Plug the mac addr setting in the "om net setup" codepath. Incrementally
configure it, so it will be set upon upgrade for bridge created before
this patch.

Example:

root@demo2:~# om net set
@ n:demo2
  ip link set dev obr_net1 address 0a:58:0a:21:04:01
  ip route replace 10.33.0.0/22 via 5.196.34.153 table main
  ip route replace 10.33.4.0/22 dev obr_net1 table main