### PR TITLE
Fix image pulling when no registry_creds is specified

### DIFF
--- a/opensvc/drivers/resource/container/docker/__init__.py
+++ b/opensvc/drivers/resource/container/docker/__init__.py
@@ -558,11 +558,15 @@ class ContainerDocker(BaseContainer):
 
     @lazy
     def registry_creds_path(self):
+        if not self.registry_creds:
+            return
         var_d = svc_pathvar(self.registry_creds_sec.path)
         return os.path.join(var_d, "registry_creds", "config.json")
 
     @lazy
     def registry_creds_sec(self):
+        if not self.registry_creds:
+            return
         return factory("sec")(self.registry_creds, namespace=self.svc.namespace, volatile=True)
 
     def docker(self, action):


### PR DESCRIPTION
The stack was:

  File "/opt/opensvc/opensvc/drivers/resource/container/docker/__init__.py", line 566, in registry_creds_sec
    return factory("sec")(self.registry_creds, namespace=self.svc.namespace, volatile=True)
  File "/opt/opensvc/opensvc/core/objects/svc.py", line 503, in __init__
    self.path = fmt_path(self.name, self.namespace, self.kind)
  File "/opt/opensvc/opensvc/utilities/naming/__init__.py", line 183, in fmt_path
    return "/".join((kind, name))