### PR TITLE
Fix om daemon restart --node 'xxx' systemd opensvc-agent desynchroniz…

### DIFF
--- a/opensvc/daemon/handlers/node/action/post.py
+++ b/opensvc/daemon/handlers/node/action/post.py
@@ -1,4 +1,5 @@
 import os
+from copy import deepcopy
 from subprocess import Popen, PIPE
 
 import daemon.handler
@@ -118,8 +119,11 @@ class Handler(daemon.handler.BaseHandler):
         fullcmd = Env.om + [subsystem] + cmd
 
         thr.log_request("run 'om %s %s'" % (subsystem, " ".join(cmd)), nodename, **kwargs)
+        new_env = deepcopy(os.environ)
+        if new_env.get('LOGNAME') is None:
+            new_env['LOGNAME'] = "root"
         if options.sync:
-            proc = Popen(fullcmd, stdout=PIPE, stderr=PIPE, stdin=None, close_fds=True)
+            proc = Popen(fullcmd, stdout=PIPE, stderr=PIPE, stdin=None, close_fds=True, env=new_env)
             out, err = proc.communicate()
             result = {
                 "status": 0,
@@ -130,7 +134,7 @@ class Handler(daemon.handler.BaseHandler):
                 },
             }
         else:
-            proc = Popen(fullcmd, stdin=None, close_fds=True)
+            proc = Popen(fullcmd, stdin=None, close_fds=True, env=new_env)
             thr.push_proc(proc)
             result = {
                 "status": 0,


### PR DESCRIPTION
…ation

Issue: When action is launched from daemon listener,
 it has no LOGNAME => some systemd daemon action lookup env LOGNAME value
 to decide if inside a systemd transition

 So run 'om daemon restart --node 'node1' does the restart without take care of systemd
 => /var/log/opensvc/node.log log is not anymore updated
 => systemd opensvc-agent active status is 'inactive (dead)' instead of 'active (running)'