### PR TITLE
Fix the handler path called by "om daemon relay status"

### DIFF
--- a/opensvc/core/node/node.py
+++ b/opensvc/core/node/node.py
@@ -4102,7 +4102,7 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
                     continue
 
         data = self.daemon_get(
-            {"action": "daemon_relay_status"},
+            {"action": "relay_status"},
             server=self.options.server,
             secret=secret,
             cluster_name=cluster_name,


### PR DESCRIPTION
Should be "GET /relay_status" instead of "GET /daemon_relay_status".