### PR TITLE
Add "GET /daemon_relay_status" as a valid route to the relay_status h…

### DIFF
--- a/opensvc/daemon/handlers/relay/status/get.py
+++ b/opensvc/daemon/handlers/relay/status/get.py
@@ -7,6 +7,7 @@ class Handler(daemon.handler.BaseHandler):
     """
     routes = (
         ("GET", "relay_status"),
+        ("GET", "daemon_relay_status"),
         (None, "daemon_relay_status"),
     )
     prototype = []


### PR DESCRIPTION
…andler

This is what newer agents use, instead of the expected (None,
"daemon_relay_status") route.