### PR TITLE
Add alternate 'reboot' suicide method for split brain cluster without…

### DIFF
--- a/opensvc/core/node/node.py
+++ b/opensvc/core/node/node.py
@@ -1724,6 +1724,17 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
         if ret != 0:
             raise ex.Error((ret, out, err))
 
+    def suicide(self, method, delay=0):
+        self.log.info('node commit suicide in %s seconds using method %s', delay, method)
+        _suicide = {
+            "crash": self.sys_crash,
+            "reboot": self.sys_reboot,
+        }.get(method)
+        if _suicide:
+            _suicide(delay)
+        else:
+            self.log.warning("invalid commit suicide method %s", method)
+
     def sys_reboot(self, delay=0):
         pass
 

--- a/opensvc/core/node/nodedict.py
+++ b/opensvc/core/node/nodedict.py
@@ -780,6 +780,16 @@ If not set, or set to ``true``, the reboot flag is removed before reboot, and a 
         "text": "Should a split segment of the cluster commit suicide. Default is False. If set to ``true``, please set at least 2 arbitrators so you can rolling upgrade the opensvc daemons."
     },
     {
+        "section": "cluster",
+        "keyword": "split_action",
+        "candidates": ["crash", "reboot"],
+        "default": "crash",
+        "text": "Commit suicide method when cluster split occur."
+                " Default is crash."
+                " reboot method may be used instead of crash when it is not"
+                " simple to poweron node after crash."
+    },
+    {
         "section": "arbitrator",
         "keyword": "name",
         "required": True,

--- a/opensvc/daemon/events.py
+++ b/opensvc/daemon/events.py
@@ -9,6 +9,7 @@ EVENTS = {
     ("arbitrator_down", None): "arbitrator {arbitrator} is no longer reachable",
     ("blacklist_add", None): "sender {sender} blacklisted",
     ("crash", "split"): "cluster is split, we don't have quorum: {node_votes}+{arbitrator_votes}/{voting} votes {pro_voters}",
+    ("reboot", "split"): "cluster is split, we don't have quorum: {node_votes}+{arbitrator_votes}/{voting} votes {pro_voters}",
     ("forget_peer", "no_rx"): "no rx thread still receive from node {peer} and maintenance grace period expired. flush its data",
     ("hb_beating", None): "node {nodename} hb status stale => beating",
     ("hb_stale", None): "node {nodename} hb status beating => stale",

--- a/opensvc/daemon/shared.py
+++ b/opensvc/daemon/shared.py
@@ -491,6 +491,7 @@ class OsvcThread(threading.Thread, Crypt):
         self.event("node_config_change")
         unset_lazy(self, "config")
         unset_lazy(self, "quorum")
+        unset_lazy(self, "split_action")
         unset_lazy(self, "vip")
         unset_lazy(NODE, "arbitrators")
         unset_lazy(self, "cluster_name")
@@ -820,6 +821,10 @@ class OsvcThread(threading.Thread, Crypt):
         return NODE.oget("cluster", "quorum")
 
     @lazy
+    def split_action(self):
+        return NODE.oget("cluster", "split_action")
+
+    @lazy
     def maintenance_grace_period(self):
         return NODE.oget("node", "maintenance_grace_period")
 
@@ -847,6 +852,14 @@ class OsvcThread(threading.Thread, Crypt):
                 votes.append(arbitrator["name"])
         return votes
 
+    @staticmethod
+    def live_nodes_count():
+        return len(CLUSTER_DATA)
+
+    @staticmethod
+    def arbitrators_config_count():
+        return len(NODE.arbitrators)
+
     def split_handler(self):
         if not self.quorum:
             self.duplog("info",
@@ -858,8 +871,8 @@ class OsvcThread(threading.Thread, Crypt):
                         "cluster is split, ignore as the node is frozen",
                         msgid="quorum disabled")
             return
-        total = len(self.cluster_nodes) + len(NODE.arbitrators)
-        live = len(CLUSTER_DATA)
+        total = len(self.cluster_nodes) + self.arbitrators_config_count()
+        live = self.live_nodes_count()
         extra_votes = self.arbitrators_votes()
         n_extra_votes = len(extra_votes)
         if live + n_extra_votes > total / 2:
@@ -868,7 +881,7 @@ class OsvcThread(threading.Thread, Crypt):
                         live=live, avote=n_extra_votes, total=total,
                         a=",".join(extra_votes))
             return
-        self.event("crash", {
+        self.event(self.split_action, {
             "reason": "split",
             "node_votes": live,
             "arbitrator_votes": n_extra_votes,
@@ -876,7 +889,7 @@ class OsvcThread(threading.Thread, Crypt):
             "pro_voters": [nod for nod in CLUSTER_DATA] + extra_votes,
         })
         # give a little time for log flush
-        NODE.sys_crash(delay=2)
+        NODE.suicide(method=self.split_action, delay=2)
 
     def forget_peer_data(self, nodename, change=False):
         """

--- a/opensvc/tests/corelib/test_core_node.py
+++ b/opensvc/tests/corelib/test_core_node.py
@@ -1,0 +1,34 @@
+import pytest
+
+from core.node import Node
+
+try:
+    # noinspection PyCompatibility
+    from unittest.mock import call
+except ImportError:
+    # noinspection PyUnresolvedReferences
+    from mock import call
+
+
+@pytest.mark.ci
+class TestNode:
+    @staticmethod
+    @pytest.mark.parametrize('split_action, expected_call', [
+        ('crash', 'sys_crash'),
+        ('reboot', 'sys_reboot'),
+    ])
+    def test_suicide_call_correct_node_method(mocker, split_action, expected_call):
+        mocker.patch.object(Node, expected_call)
+        node = Node()
+        node.suicide(method=split_action, delay=6)
+        getattr(node, expected_call).assert_called_once_with(6)
+
+    @staticmethod
+    def test_suicide_with_invalid_method_log_warning(mocker):
+        node = Node()
+        mocker.patch.object(node.log, 'warning')
+        node.suicide(method="invalid_split_action", delay=6)
+        expected_warning_calls = [
+            call('invalid commit suicide method %s', 'invalid_split_action'),
+        ]
+        node.log.warning.assert_has_calls(expected_warning_calls)

--- a/opensvc/tests/daemon/test_shared.py
+++ b/opensvc/tests/daemon/test_shared.py
@@ -9,6 +9,11 @@ from env import Env
 
 
 @pytest.fixture(scope='function')
+def suicide(mocker):
+    return mocker.patch.object(Node, 'suicide')
+
+
+@pytest.fixture(scope='function')
 @pytest.mark.usefixtures('osvc_path_tests')
 def thr(osvc_path_tests, mocker):
     shared_thr = shared.OsvcThread()
@@ -46,3 +51,70 @@ class TestSharedRemoveClusterNode:
     def test_log_warning_if_called_with_empty_nodename(thr, nodename):
         thr.remove_cluster_node(nodename)
         thr.log.warning.assert_called_once_with('remove_cluster_node called with empty nodename')
+
+
+@pytest.mark.ci
+@pytest.mark.usefixtures('osvc_path_tests')
+class TestSplitHandlerWhenQuorumKwIsTrue:
+    @staticmethod
+    @pytest.mark.parametrize('split_action, expected', [
+        [None, 'crash'],
+        ['crash', 'crash'],
+        ['reboot', 'reboot'],
+    ])
+    def test_when_need_suicide_use_correct_split_action(mocker, suicide, thr, split_action, expected):
+        if split_action:
+            setattr(thr, '_lazy_split_action', split_action)
+        thr._lazy_quorum = True
+        thr._lazy_cluster_nodes = thr.cluster_nodes + ['node2']
+        mocker.patch.object(thr, 'arbitrators_votes', return_value=[])
+        thr.split_handler()
+        suicide.assert_called_once_with(delay=2, method=expected)
+
+    @staticmethod
+    @pytest.mark.parametrize('cfg_nodes, cfg_arbitrators, live_nodes, arbitrator_votes, split_action_count', [
+        # 2 nodes, 0 arbitrator: total votes = 2
+        [2, 0, 2, 0, 0],  # 2 nodes alive, 0 arbitrator vote, no suicide
+        [2, 0, 1, 0, 1],  # 1 nodes alive, 0 arbitrator vote, suicide
+
+        # 2 nodes, 1 arbitrator: total votes = 3
+        [2, 1, 2, 0, 0],  # 2 nodes alive, 0 arbitrator vote, no suicide
+        [2, 1, 2, 1, 0],  # 2 nodes alive, 1 arbitrator vote, no suicide
+        [2, 1, 1, 1, 0],  # 1 node alive, 1 arbitrator vote => no suicide
+        [2, 1, 1, 0, 1],  # 1 node alive, no arbitrator vote => suicide
+
+        # 3 nodes, 1 arbitrator: total votes = 4
+        [3, 1, 3, 1, 0],  # 3 nodes alive, 1 arbitrator vote, no suicide
+        [3, 1, 3, 0, 0],  # 3 nodes alive, 0 arbitrator vote, no suicide
+        [3, 1, 2, 1, 0],  # 2 nodes alive, 1 arbitrator vote, no suicide
+        [3, 1, 1, 1, 1],  # 1 node alive, 1 arbitrator vote, suicide
+        [3, 1, 1, 0, 1],  # 1 node alive, 0 arbitrator vote, suicide
+
+        # 3 nodes, 2 arbitrator: total votes = 5
+        [3, 2, 3, 2, 0],  # 3 nodes alive, 2 arbitrator vote, no suicide
+        [3, 2, 3, 1, 0],  # 3 nodes alive, 1 arbitrator vote, no suicide
+        [3, 2, 3, 0, 0],  # 3 nodes alive, 0 arbitrator vote, no suicide
+        [3, 2, 2, 2, 0],  # 2 nodes alive, 2 arbitrator vote, no suicide
+        [3, 2, 2, 1, 0],  # 2 nodes alive, 1 arbitrator vote, no suicide
+        [3, 2, 2, 0, 1],  # 2 nodes alive, 0 arbitrator vote, suicide
+        [3, 2, 1, 2, 0],  # 1 nodes alive, 2 arbitrator vote, no suicide
+        [3, 2, 1, 1, 1],  # 1 nodes alive, 1 arbitrator vote, suicide
+        [3, 2, 1, 0, 1],  # 1 nodes alive, 0 arbitrator vote, suicide
+    ])
+    def test_call_suicide(
+            mocker,
+            suicide,
+            thr,
+            cfg_nodes,
+            cfg_arbitrators,
+            live_nodes,
+            arbitrator_votes,
+            split_action_count):
+        thr._lazy_quorum = True
+        thr._lazy_cluster_nodes = thr.cluster_nodes + ['node' + str(i) for i in range(1, cfg_nodes)]
+        mocker.patch.object(thr, 'arbitrators_config_count', return_value=cfg_arbitrators)
+        mocker.patch.object(thr, 'live_nodes_count', return_value=live_nodes)
+        mocker.patch.object(thr, 'arbitrators_votes',
+                            return_value=["arb" + str(i) for i in range(0, arbitrator_votes)])
+        thr.split_handler()
+        assert suicide.call_count == split_action_count


### PR DESCRIPTION
… enough votes

When power-on feature is not easy to use, it may be simpler to reboot node instead of crash node.

New kw added: cluster.suicide_method
It can be defined in node.conf or cluster.conf, and can have 'crash' or 'reboot' value.
When undefined, 'crash' value it used.

When defined to 'reboot', a reboot is called instead of default 'crash' when split cluster doesn't get enough
votes during split brain situation.