### PR TITLE
Fix the "daemon_join" action via the POST /node_action handler

### DIFF
--- a/opensvc/daemon/handlers/node/action/post.py
+++ b/opensvc/daemon/handlers/node/action/post.py
@@ -55,7 +55,7 @@ class Handler(daemon.handler.BaseHandler):
             }
 
         for opt in ("node", "server", "daemon"):
-            if opt in options.options:
+            if opt in options.options and options.action not in ("daemon_join", "daemon_rejoin"):
                 del options.options[opt]
         if options.action_mode and options.options.get("local"):
             if "local" in options.options:


### PR DESCRIPTION
This action would report unset "node" option even if set in the request
payload, because it deletes it thinking its a request routing information.

Make sure we preserve the "node" option for actions that use it, ie
daemon_join and daemon_rejoin.