### PR TITLE
Align the POST /node_action result with POST /object_action

### DIFF
--- a/opensvc/daemon/handlers/node/action/post.py
+++ b/opensvc/daemon/handlers/node/action/post.py
@@ -134,10 +134,17 @@ class Handler(daemon.handler.BaseHandler):
                 },
             }
         else:
+            import uuid
+            session_id = str(uuid.uuid4())
+            new_env["OSVC_PARENT_SESSION_UUID"] = session_id
             proc = Popen(fullcmd, stdin=None, close_fds=True, env=new_env)
-            thr.parent.push_proc(proc)
+            thr.parent.push_proc(proc, cmd=fullcmd, session_id=session_id)
             result = {
                 "status": 0,
+                "data": {
+                    "pid": proc.pid,
+                    "session_id": session_id,
+                },
                 "info": "started node action %s" % " ".join(cmd),
             }
         return result


### PR DESCRIPTION
Add the data.pid and data.session_id keys to the result.

Pass the session_id and cmd to push_proc, so node_action process can be filtered
by session_id via the GET /daemon_actions handler.

Example:

$ echo '{"method": "POST", "action": "node_action", "options": {"action": "compliance_check", "sync": false}}' | sudo socat -t15 - /opt/opensvc/var/lsnr/lsnr.sock|jq
{
  "status": 0,
  "data": {
    "pid": 317463,
    "session_id": "5bf844bd-f4be-4315-8c42-c215a50da488"
  },
  "info": "started node action compliance_check --local"
}

$ echo '{"method": "GET", "action": "daemon_actions", "options": {"thread": "listener"}}' | sudo socat -t15 - /opt/opensvc/var/lsnr/lsnr.sock|jq
{
  "status": 0,
  "data": [
    {
      "thread": "listener",
      "pid": 317463,
      "session_id": "5bf844bd-f4be-4315-8c42-c215a50da488",
      "cmd": [
        "/usr/bin/python3",
        "-m",
        "opensvc",
        "node",
        "compliance_check",
        "--local"
      ]
    }
  ]
}