### PR TITLE
Fix sync.srdfs promote_devs_rw() when syminq does not report /dev/map…

### DIFF
--- a/lib/resSyncSymSrdfS.py
+++ b/lib/resSyncSymSrdfS.py
@@ -86,7 +86,8 @@ class syncSymSrdfS(resSync.Sync):
     def promote_devs_rw(self):
         if rcEnv.sysname != "Linux":
             return
-        devs = [d for d in self.list_pd() if d.startswith("/dev/mapper/") or d.startswith("/dev/rdsk/")]
+        devs = self.list_pd()
+        devs = [d for d in devs if d.startswith("/dev/mapper/") or d.startswith("/dev/dm-") or d.startswith("/dev/rdsk/")]
         for dev in devs:
             self.promote_dev_rw(dev)
 


### PR DESCRIPTION
…per/ devs

syminq has been seeon on SLES 15 reporting only /dev/dm-* devs and not their
/dev/mapper/* equivalent. But the sync.srdfs driver discards all devs but
/dev/mapper/* ones.

Change the filter to allow /dev/dm-* devs too. Now we can call promote_dev_rw()
twice for the same disk (one /dev/dm-* and one /dev/mapper/*), but this
function will detect it has nothing more to do.