### PR TITLE
Add the comment keyword in all data sections

### DIFF
--- a/opensvc/core/objects/cfgdict.py
+++ b/opensvc/core/objects/cfgdict.py
@@ -75,7 +75,7 @@ KEYWORDS = [
         "example": "node1 node2"
     },
     {
-        "sections": ["DEFAULT"],
+        "section": "DEFAULT",
         "keyword": "comment",
         "default": "",
         "text": "Helps users understand the role of the service and resources, which is nice to on-call support people having to operate on a service they are not usually responsible for."

--- a/opensvc/core/objects/secdict.py
+++ b/opensvc/core/objects/secdict.py
@@ -167,7 +167,7 @@ KEYWORDS = [
         "example": "ca",
     },
     {
-        "sections": ["DEFAULT"],
+        "section": "DEFAULT",
         "keyword": "comment",
         "default": "",
         "text": "Helps users understand the role of the service and resources, which is nice to on-call support people having to operate on a service they are not usually responsible for."

--- a/opensvc/core/objects/svcdict.py
+++ b/opensvc/core/objects/svcdict.py
@@ -1236,7 +1236,7 @@ KEYWORDS = [
         "example": "50"
     },
     {
-        "sections": SECTIONS + ["subset"],
+        "sections": DATA_SECTIONS + SECTIONS + ["subset"],
         "keyword": "comment",
         "default": "",
         "text": "Helps users understand the role of the service and resources, which is nice to on-call support people having to operate on a service they are not usually responsible for."

--- a/opensvc/core/objects/usrdict.py
+++ b/opensvc/core/objects/usrdict.py
@@ -167,13 +167,13 @@ KEYWORDS = [
         "example": "ca",
     },
     {
-        "sections": ["DEFAULT"],
+        "section": "DEFAULT",
         "keyword": "comment",
         "default": "",
         "text": "Helps users understand the role of the service and resources, which is nice to on-call support people having to operate on a service they are not usually responsible for."
     },
     {
-        "sections": ["DEFAULT"],
+        "section": "DEFAULT",
         "keyword": "grant",
         "example": "admin:test* guest:*",
         "text": "Grant roles on namespaces to the user. A whitespace-separated list of root|squatter|blacklistadmin|<role selector>:<namespace selector>, where role selector is a comma-separated list of role in admin,operator,guest and the namespace selector is a glob pattern applied to existing namespaces. The root role is required to add resource triggers and non-containerized resources other than (container.docker, container.podman task.docker, task.podman and volume). The squatter role is required to create a new namespace. The admin role is required to create, deploy and delete objects. The guest role is required to list and read objects configurations and status."


### PR DESCRIPTION
Without this patch, the following config produces an error :

[expose#1]
type = envoy
listener_certificates = certificate#0
...