### PR TITLE
Fix a warning stack on svc action when args contain a "%"

### DIFF
--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -1338,7 +1338,7 @@ class BaseSvc(Crypt, ExtConfigMixin):
                 else:
                     _begin = 1
                 argv = self.log_action_obfuscate_secret(argv)
-                runlog = "do "+" ".join(argv[_begin:])
+                runlog = "do "+" ".join(argv[_begin:]).replace("%", "%%")
                 if os.environ.get("OSVC_ACTION_ORIGIN") == "daemon":
                     runlog += " (daemon origin)"
                 else:


### PR DESCRIPTION
The agent logs the command, and the log function interprets the % as a
substitution wildcard.

Example:

om testvg1 update \
  --resource '{"rtype": "disk", "type": "lv", "vg": "{svcname}", "size": "100%FREE", "name": "root"}' \
  --disable-rollback