### PR TITLE
Add the "interval" option to all heartbeat drivers configuration syntax

### DIFF
--- a/opensvc/core/node/nodedict.py
+++ b/opensvc/core/node/nodedict.py
@@ -879,6 +879,14 @@ Arbitrators can be tested using :cmd:`om node ping --node <arbitrator name>`.
     },
     {
         "section": "hb",
+        "keyword": "interval",
+        "convert": "duration",
+        "at": True,
+        "default": 5,
+        "text": "The interval between tx threads data sends."
+    },
+    {
+        "section": "hb",
         "keyword": "addr",
         "rtype": "multicast",
         "at": True,

--- a/opensvc/daemon/hb/disk.py
+++ b/opensvc/daemon/hb/disk.py
@@ -35,6 +35,7 @@ class HbDisk(Hb):
         data["config"] = {
             "dev": self.dev,
             "timeout": self.timeout,
+            "interval": self.interval,
         }
         for peer in data["peers"]:
             data["peers"][peer].update(self.peer_config.get(peer, {}))
@@ -62,6 +63,7 @@ class HbDisk(Hb):
             self.slot_buff = mmap.mmap(-1, self.SLOTSIZE)
 
         self.timeout = shared.NODE.oget(self.name, "timeout")
+        self.interval = shared.NODE.oget(self.name, "interval")
         try:
             new_dev = shared.NODE.oget(self.name, "dev")
         except ex.RequiredOptNotFound:
@@ -232,7 +234,7 @@ class HbDiskTx(HbDisk):
                 if self.stopped():
                     sys.exit(0)
                 with shared.HB_TX_TICKER:
-                    shared.HB_TX_TICKER.wait(self.default_hb_period)
+                    shared.HB_TX_TICKER.wait(self.interval)
         except Exception as exc:
             self.log.exception(exc)
 
@@ -301,7 +303,7 @@ class HbDiskRx(HbDisk):
             if self.stopped():
                 sys.exit(0)
             with shared.HB_TX_TICKER:
-                shared.HB_TX_TICKER.wait(self.default_hb_period)
+                shared.HB_TX_TICKER.wait(self.interval)
 
     def missing_peers(self):
         return [nodename for nodename, data in self.peer_config.items() if hasattr(data, "slot") and data.slot < 0]

--- a/opensvc/daemon/hb/hb.py
+++ b/opensvc/daemon/hb/hb.py
@@ -15,7 +15,7 @@ class Hb(shared.OsvcThread):
     """
     Heartbeat parent class
     """
-    default_hb_period = 5
+    interval = 5
     timeout = None
 
     def __init__(self, name, role=None):
@@ -127,9 +127,12 @@ class Hb(shared.OsvcThread):
             else:
                 self.event("hb_stale", data={
                     "nodename": nodename,
-                    "hb": {"name": self.name, "id": self.id,
-                           "timeout": self.timeout,
-                           "last": self.peers[nodename].last},
+                    "hb": {
+                        "name": self.name, "id": self.id,
+                        "timeout": self.timeout,
+                        "interval": self.interval,
+                        "last": self.peers[nodename].last,
+                    },
                 }, level="warning")
         self.peers[nodename].beating = beating
         if not beating and self.peers[nodename].last > 0:

--- a/opensvc/daemon/hb/mcast.py
+++ b/opensvc/daemon/hb/mcast.py
@@ -27,7 +27,6 @@ class HbMcast(Hb):
     src_addr = None
     port = None
     intf = None
-    timeout = None
     addr = None
     sock = None
     max_data = 1000
@@ -41,6 +40,7 @@ class HbMcast(Hb):
             "intf": self.intf,
             "src_addr": self.src_addr,
             "timeout": self.timeout,
+            "interval": self.interval,
         }
         return data
 
@@ -64,11 +64,13 @@ class HbMcast(Hb):
             "port": self.port,
             "addr": self.addr,
             "intf": self.intf,
-            "timeout": self.timeout
+            "timeout": self.timeout,
+            "interval": self.interval
         }
         self.port = shared.NODE.oget(self.name, "port")
         self.addr = shared.NODE.oget(self.name, "addr")
         self.timeout = shared.NODE.oget(self.name, "timeout")
+        self.interval = shared.NODE.oget(self.name, "interval")
         group = socket.inet_aton(self.addr)
         try:
             self.intf = shared.NODE.conf_get(self.name, "intf")
@@ -156,7 +158,7 @@ class HbMcastTx(HbMcast):
                     self.sock.close()
                     sys.exit(0)
                 with shared.HB_TX_TICKER:
-                    shared.HB_TX_TICKER.wait(self.default_hb_period)
+                    shared.HB_TX_TICKER.wait(self.interval)
         except Exception as exc:
             self.log.exception(exc)
 

--- a/opensvc/daemon/hb/relay.py
+++ b/opensvc/daemon/hb/relay.py
@@ -19,6 +19,7 @@ class HbRelay(Hb):
         data["stats"] = self.stats
         data["config"] = {
             "timeout": self.timeout,
+            "interval": self.interval,
         }
         if hasattr(self, "relay"):
             data["config"]["relay"] = self.relay
@@ -38,6 +39,7 @@ class HbRelay(Hb):
         self.get_hb_nodes()
         self.peer_config = {}
         self.timeout = shared.NODE.oget(self.name, "timeout")
+        self.interval = shared.NODE.oget(self.name, "interval")
         try:
             self.relay = shared.NODE.oget(self.name, "relay")
         except Exception:
@@ -73,7 +75,7 @@ class HbRelayTx(HbRelay):
                 if self.stopped():
                     sys.exit(0)
                 with shared.HB_TX_TICKER:
-                    shared.HB_TX_TICKER.wait(self.default_hb_period)
+                    shared.HB_TX_TICKER.wait(self.interval)
         except Exception as exc:
             self.log.exception(exc)
 
@@ -143,7 +145,7 @@ class HbRelayRx(HbRelay):
             if self.stopped():
                 sys.exit(0)
             with shared.HB_TX_TICKER:
-                shared.HB_TX_TICKER.wait(self.default_hb_period)
+                shared.HB_TX_TICKER.wait(self.interval)
 
     def do(self):
         self.janitor_procs()

--- a/opensvc/daemon/hb/ucast.py
+++ b/opensvc/daemon/hb/ucast.py
@@ -71,10 +71,14 @@ class HbUcast(Hb):
             self.peer_config = peer_config
 
         timeout = shared.NODE.oget(self.name, "timeout")
-
         if timeout != self.timeout:
             self.config_change = True
             self.timeout = timeout
+
+        interval = shared.NODE.oget(self.name, "interval")
+        if interval != self.interval:
+            self.config_change = True
+            self.interval = interval
 
         self.max_handlers = len(self.hb_nodes) * 4
 
@@ -100,7 +104,7 @@ class HbUcastTx(HbUcast):
                 if self.stopped():
                     sys.exit(0)
                 with shared.HB_TX_TICKER:
-                    shared.HB_TX_TICKER.wait(self.default_hb_period)
+                    shared.HB_TX_TICKER.wait(self.interval)
         except Exception as exc:
             self.log.exception(exc)
 


### PR DESCRIPTION
To allow users to change from the 3s default.

Lowering the interval permits to lower the "timeout" from the default 15s,
and the "node.ready_period" from the default 5s.

This kind of tuning can be used on clusters with few data-less services
that need fast recovery (4s minimum).

Example:

[node]
ready_period = 2s

[hb#1]
type = unicast
timeout = 2s
interval = 1s