### PR TITLE
Fix a resource info clear issue at the begining of tasks run action

### DIFF
--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -3885,7 +3885,7 @@ class Svc(PgMixin, BaseSvc):
         nscfg = self.nscfg()
         if not nscfg:
             return
-        nscfg.pg_update()
+        nscfg.pg_update(children=False)
 
     def do_pre_monitor_action(self):
         if self.pre_monitor_action is None:

--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -3773,10 +3773,7 @@ class Svc(PgMixin, BaseSvc):
             for resource in rset.resources:
                 status = core.status.Status(resource.status(verbose=True))
                 log = resource.status_logs_strlist()
-                if refresh:
-                    info = resource.status_info()
-                else:
-                    info = resource.last_status_info
+                info = resource.last_status_info # refreshed by resource.status() if necessary
                 tags = sorted(list(resource.tags))
                 disable = resource.is_disabled()
                 _data = {

--- a/opensvc/core/resource.py
+++ b/opensvc/core/resource.py
@@ -551,6 +551,7 @@ class Resource(object):
             self.status_logs = []
             self.rstatus = self.try_status(verbose)
             self.rstatus = self.status_stdby(self.rstatus)
+            self.last_status_info = self.status_info()
             self.log.debug("refresh status: %s => %s",
                            core.status.Status(last_status),
                            core.status.Status(self.rstatus))

--- a/opensvc/core/scheduler.py
+++ b/opensvc/core/scheduler.py
@@ -1062,23 +1062,23 @@ class Scheduler(object):
         else:
             param = schedule_option
         param = '.'.join((section, param))
+
+        data = dict(
+            action=action,
+            last_run=last_s,
+            config_parameter=param,
+            schedule_definition=schedule_s,
+        )
+
         if self.options.verbose:
-            result = self.get_next_schedule(action)
-            if result["next_sched"]:
+            if schedule_s in ("-", "@0", "malformed"):
+                result = None
+            else:
+                result = self.get_next_schedule(action)
+            if result and result["next_sched"]:
                 next_s = result["next_sched"].strftime("%Y-%m-%d %H:%M")
             else:
                 next_s = "-"
-            return dict(
-                action=action,
-                last_run=last_s,
-                next_run=next_s,
-                config_parameter=param,
-                schedule_definition=schedule_s
-            )
-        else:
-            return dict(
-                action=action,
-                last_run=last_s,
-                config_parameter=param,
-                schedule_definition=schedule_s,
-            )
+            data["next_run"] = next_s
+
+        return data


### PR DESCRIPTION
This is an issue because the ip info contains the ipaddr exposed via the
cluster dns. So the ip resource could lose the resolution on run actions
if a resolution query is submitted during the run action.

This patch moves the Resource::status_info() call out of Svc::status_data_eval()
to Resource::status(), so everytime status() refreshes the main status data it
also updates the status_info() and updates the cache. Which garanty the
last_status_data cache file contains a valid "info" section.