### PR TITLE
Fix PTR records

### DIFF
--- a/opensvc/daemon/dns.py
+++ b/opensvc/daemon/dns.py
@@ -481,7 +481,7 @@ class Dns(shared.OsvcThread):
                     gen_name = "%s.%s.%s.%s." % (name, namespace, kind, self.cluster_name)
                     gen_name = gen_name.lower()
                     if hostname and hostname != name:
-                        target = "%s%s" % (hostname, gen_name)
+                        target = "%s.%s" % (hostname, gen_name)
                     else:
                         target = "%s" % gen_name
                     if target in names[qname]:


### PR DESCRIPTION
* Before
156.3.33.10.in-addr.arpa.                   IN   PTR    60  demo1prometheus.mon.svc.dev.
224.4.33.10.in-addr.arpa.                   IN   PTR    60  demo2netdata.mon.svc.dev.
226.4.33.10.in-addr.arpa.                   IN   PTR    60  demo2prometheus.mon.svc.dev.

* After
156.3.33.10.in-addr.arpa.                   IN   PTR    60  demo1.prometheus.mon.svc.dev.
224.4.33.10.in-addr.arpa.                   IN   PTR    60  demo2.netdata.mon.svc.dev.
226.4.33.10.in-addr.arpa.                   IN   PTR    60  demo2.prometheus.mon.svc.dev.