### PR TITLE
Fix undue volume instance stop on user instance's stop

### DIFF
--- a/opensvc/core/objects/vol.py
+++ b/opensvc/core/objects/vol.py
@@ -1,5 +1,23 @@
+import core.status
+
 from core.objects.svc import Svc
+from utilities.naming import split_path, factory
 
 class Vol(Svc):
     kind = "vol"
+
+    def users(self, exclude=None):
+        exclude = exclude or []
+        users = []
+        for child in self.children:
+            if child in exclude:
+                continue
+            name, namespace, kind = split_path(child)
+            obj = factory(kind)(name=name, namespace=self.namespace, volatile=True, node=self.node)
+            for res in obj.get_resources("volume"):
+                if res.name != self.name:
+                    continue
+                if res.status() in (core.status.UP, core.status.STDBY_UP, core.status.WARN):
+                    users.append(child)
+        return users
 

--- a/opensvc/drivers/resource/volume/__init__.py
+++ b/opensvc/drivers/resource/volume/__init__.py
@@ -260,6 +260,11 @@ class Volume(Resource):
         if not self.volsvc.exists():
             self.log.info("volume %s does not exist", self.volname)
             return
+        users = self.volsvc.users(exclude=[self.svc.path])
+        if users:
+            self.log.info(f"skip {self.volsvc.path} stop: active users: {','.join(users)}")
+            return
+        self.log.info(f"last user of {self.volsvc.path} on this node: stop the volume instance")
         if self.volsvc.topology == "flex":
             return
         if self.volsvc.action("stop", options={"local": True, "leader": self.svc.options.leader, "force": force}) != 0:

--- a/opensvc/drivers/resource/volume/__init__.py
+++ b/opensvc/drivers/resource/volume/__init__.py
@@ -262,9 +262,11 @@ class Volume(Resource):
             return
         users = self.volsvc.users(exclude=[self.svc.path])
         if users:
-            self.log.info(f"skip {self.volsvc.path} stop: active users: {','.join(users)}")
+            self.log.info("skip %s stop: active users: %s",
+                          self.volsvc.path, ",".join(users))
             return
-        self.log.info(f"last user of {self.volsvc.path} on this node: stop the volume instance")
+        self.log.info("last user of %s on this node: stop the volume instance",
+                      self.volsvc.path)
         if self.volsvc.topology == "flex":
             return
         if self.volsvc.action("stop", options={"local": True, "leader": self.svc.options.leader, "force": force}) != 0:

--- a/opensvc/utilities/asset/asset.py
+++ b/opensvc/utilities/asset/asset.py
@@ -632,7 +632,7 @@ class BaseAsset(object):
         l = out.split()
 
         i = 0
-        for s in ("days,", "day(s),"):
+        for s in ("days,", "day(s),", "day,", "days", "day"):
             try:
                 i = l.index(s)
                 break


### PR DESCRIPTION
Don't try to stop a volume instance from a user's instance stop if other user
instances are running.