### PR TITLE
Relax shared volumes claim restrictions

### DIFF
--- a/opensvc/drivers/resource/share/nfs/linux.py
+++ b/opensvc/drivers/resource/share/nfs/linux.py
@@ -45,7 +45,7 @@ class ShareNfs(Resource):
     @cache("showmount.e")
     def get_showmount(self):
         self.data = {}
-        cmd = ["showmount", "-e", "--no-headers"]
+        cmd = ["showmount", "-e", "--no-headers", "127.0.0.1"]
         out, err, ret = justcall(cmd)
         if ret != 0:
             raise ex.Error("nfs server not operational")
@@ -135,10 +135,10 @@ class ShareNfs(Resource):
                 continue
 
             if client in self.issues_wrong_opts:
-                cmd = [ 'exportfs', '-u', ':'.join((client, self.path)) ]
+                cmd = ["exportfs", "-i", "-u", ":".join((client, self.path))]
                 ret, out, err = self.vcall(cmd)
 
-            cmd = [ 'exportfs', '-o', ','.join(opts), ':'.join((client, self.path)) ]
+            cmd = ["exportfs", "-i", "-o", ",".join(opts), ":".join((client, self.path))]
             ret, out, err = self.vcall(cmd)
             clear_cache("exportfs.v")
             clear_cache("showmount.e")


### PR DESCRIPTION
Shared volumes could be claimed by only one service.

This patch,

* allows a service declaring the first claimer as a local parent to
claim to volume too.

* make the provisioning keywords optional, so only the first claimer/provisioner
must declare these keywords (size, type, ...).

Example:

* 1st claimer: svc1

[volume#1]
name = db-backup
size = 1g
shared = true

* 2nd claimer: svc2

[DEFAULT]
parents = svc1@{nodename}

[volume#1]
name = db-backup
shared = true