### PR TITLE
Accept 'B' unit during convert_size

### DIFF
--- a/opensvc/tests/test_converters.py
+++ b/opensvc/tests/test_converters.py
@@ -115,40 +115,58 @@ class TestConverters:
             assert False
 
     @staticmethod
-    def test_convert_size():
-        """
-        Converter, size
-        """
-        assert convert_size("1k") == 1024
-        assert convert_size("1K") == 1024
-        assert convert_size("1KB") == 1024
-        assert convert_size("1 K") == 1024
-        assert convert_size("1 Ki") == 1000
-        assert convert_size("1 KiB") == 1000
-        assert convert_size("1.1 Ki") == 1100
-        assert convert_size(1000000, _to="Ki") == 1000
-        assert convert_size(1000, _to="B") == 1000
-        assert convert_size(None) is None
-        assert convert_size(1100) == 1100
-        assert convert_size(1100.0) == 1100
-        assert convert_size("50%FREE") == "50%FREE"
-        assert convert_size("") == 0
-        assert convert_size("0") == 0
-        assert convert_size(10000, _round=4096) == 8192
-        try:
-            convert_size("1j")
-            assert False
-        except ValueError:
-            pass
-        except Exception:
-            assert False
-        try:
-            convert_size("1", _to="j")
-            assert False
-        except ValueError:
-            pass
-        except Exception:
-            assert False
+    @pytest.mark.parametrize("size, expected_size, kwargs", [
+        ["0B", 0, {}],
+        ["10B", 10, {}],
+        ["1k", 1024, {}],
+        ["1mb", 1048576, {}],
+        ["1MB", 1048576, {}],
+        ["1GB", 1073741824, {}],
+        ["1Gb", 1073741824, {}],
+        ["1 GB", 1073741824, {}],
+        ["1 G", 1073741824, {}],
+        ["1K", 1024, {}],
+        ["1KB", 1024, {}],
+        ["1 k", 1024, {}],
+        ["1 K", 1024, {}],
+        ["1 Ki", 1000, {}],
+        ["1 KiB", 1000, {}],
+        ["1 KiB", 1000, {}],
+        ["1.1 Ki", 1100, {}],
+        ["1.1 ki", 1100, {}],
+        ["1000000", 1000, {"_to": "Ki"}],
+        ["1000", 1000, {"_to": "B"}],
+        [None, None, {}],
+        ["1100", 1100, {}],
+        ["1100.0", 1100, {}],
+        ["50%FREE", "50%FREE", {}],
+        ["", 0, {}],
+        ["0", 0, {}],
+        ["10000", 8192, {"_round": 4096}],
+    ])
+    def test_convert_size_is_correct(size, expected_size, kwargs):
+        assert convert_size(size, **kwargs) == expected_size
+
+    @staticmethod
+    @pytest.mark.parametrize("value", [
+        "1j",
+        "1d",
+        "100y",
+    ])
+    def test_convert_size_raise_value_error_when_value_has_invalid_unit(value):
+        with pytest.raises(ValueError):
+            convert_size(value)
+
+    @staticmethod
+    @pytest.mark.parametrize("to", [
+        "j",
+        "d",
+        "y",
+        "a",
+    ])
+    def test_convert_size_raise_value_error_when_to_has_invalid_unit(to):
+        with pytest.raises(ValueError):
+            convert_size("1", _to=to)
 
     @staticmethod
     def test_print_size():

--- a/opensvc/utilities/converters/__init__.py
+++ b/opensvc/utilities/converters/__init__.py
@@ -270,6 +270,7 @@ def convert_size(s, _to='', _round=1, default_unit=''):
         return s
     l = ['', 'K', 'M', 'G', 'T', 'P', 'Z', 'E']
     s = s.strip().replace(",", ".")
+    s = s.replace("B", "")
     if len(s) == 0:
         return 0
     if s == '0':


### PR DESCRIPTION
This patch fix following stack

    $ om node checks
    Traceback (most recent call last):
      File "/usr/share/opensvc/opensvc/utilities/converters/__init__.py", line 295, in convert_size
        start_idx = l.index(unit)
    ValueError: 'B' is not in list

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/usr/lib/python3.8/runpy.py", line 193, in _run_module_as_main
        return _run_code(code, main_globals, None,
      File "/usr/lib/python3.8/runpy.py", line 86, in _run_code
        exec(code, run_globals)
      File "/usr/share/opensvc/opensvc/__main__.py", line 124, in <module>
        ret = main()
      File "/usr/share/opensvc/opensvc/__main__.py", line 97, in main
        ret = main(argv=sys.argv[2:])
      File "/usr/share/opensvc/opensvc/commands/node/__init__.py", line 65, in main
        return _main(node, argv=argv)
      File "/usr/share/opensvc/opensvc/commands/node/__init__.py", line 45, in _main
        err = node.action(action)
      File "/usr/share/opensvc/opensvc/core/node/node.py", line 966, in action
        return self._action(action, options)
      File "/usr/share/opensvc/opensvc/core/scheduler.py", line 114, in _func
        ret = func(self, action, options)
      File "/usr/share/opensvc/opensvc/core/node/node.py", line 996, in _action
        ret = getattr(self, action)()
      File "/usr/share/opensvc/opensvc/core/node/node.py", line 1703, in checks
        data = checkers.do_checks()
      File "/usr/share/opensvc/opensvc/drivers/check/__init__.py", line 102, in do_checks
        _data = chk.do_check()
      File "/usr/share/opensvc/opensvc/drivers/check/fs_u/zfs/__init__.py", line 64, in do_check
        avail = convert_size(l[2], _to="KB")
      File "/usr/share/opensvc/opensvc/utilities/converters/__init__.py", line 297, in convert_size
        raise ValueError("convert size error: unsupported unit in %s" % s)
    ValueError: convert size error: unsupported unit in 0B