### PR TITLE
Fix stats_meminfo error on Solaris 11.4

### DIFF
--- a/lib/nodeSunOS.py
+++ b/lib/nodeSunOS.py
@@ -48,8 +48,8 @@ class Node(node.Node):
             if line[0] != "/":
                 continue
             elem = line.split()
-            swap_avail += int(elem[-1]) // 2
-            swap_total += int(elem[-2]) // 2
+            swap_avail += int(elem[4]) // 2
+            swap_total += int(elem[3]) // 2
         data["swap_avail"] = 100 - swap_avail // swap_total
         data["swap_total"] = swap_total // 1024
 


### PR DESCRIPTION
Because swap -l add extra 'encrypted' computation of avail and swap size is now incorrect

This commit fix following stack:
    Exception in thread monitor:
    Traceback (most recent call last):
      File "/opt/python3/lib/python3.6/threading.py", line 916, in _bootstrap_inner
        self.run()
      File "/usr/share/opensvc/lib/osvcd_mon.py", line 146, in run
        self.init()
      File "/usr/share/opensvc/lib/osvcd_mon.py", line 142, in init
        self.update_hb_data()
      File "/usr/share/opensvc/lib/osvcd_mon.py", line 3268, in update_hb_data
        self.update_cluster_data()
      File "/usr/share/opensvc/lib/osvcd_mon.py", line 3204, in update_cluster_data
        self.update_node_data()
      File "/usr/share/opensvc/lib/osvcd_mon.py", line 3223, in update_node_data
        data["stats"] = shared.NODE.stats()
      File "/usr/share/opensvc/lib/node.py", line 5095, in stats
        meminfo = self.stats_meminfo()
      File "/usr/share/opensvc/lib/nodeSunOS.py", line 51, in stats_meminfo
        swap_avail += int(elem[-1]) // 2
    ValueError: invalid literal for int() with base 10: 'yes'