### PR TITLE
Fix daemon start failure (after node crash, when new pid is same a pr…

### DIFF
--- a/lib/osvcd.py
+++ b/lib/osvcd.py
@@ -183,18 +183,33 @@ class Daemon(object):
 
         try:
             with cmlock(lockfile=rcEnv.paths.daemon_lock, timeout=1, delay=1):
-                if daemon_process_running():
-                    self.log.error("a daemon process is already running")
+                if self._already_running():
+                    self.log.error("abort start: a daemon process is already running")
                     sys.exit(1)
                 self.write_pid()
         except LockTimeout:
-            self.log.error("a daemon is already running, and holding the "
-                           "daemon lock")
+            self.log.error("abort start: a daemon is already running, and holding the daemon lock")
             sys.exit(1)
         self.loop_forever()
 
+    def _already_running(self):
+        if daemon_process_running():
+            try:
+                with open(rcEnv.paths.daemon_pid, "r") as pid_file:
+                    last_pid_trace = pid_file.read()
+            except:
+                self.log.error("another daemon process detected, but file error on %s" % rcEnv.paths.daemon_pid)
+                return True
+            if last_pid_trace == str(self.pid):
+                return False
+            else:
+                self.log.error("another daemon process is already running with pid %s" % last_pid_trace)
+                return True
+        else:
+            return False
+
     def write_pid(self):
-        pid = str(self.pid)+"\n"
+        pid = str(self.pid)
         with open(rcEnv.paths.daemon_pid, "w") as ofile:
             ofile.write(pid)
         _, pid_args = process_args(self.pid)

--- a/lib/tests/test_osvcd.py
+++ b/lib/tests/test_osvcd.py
@@ -4,6 +4,11 @@ import pytest
 from rcGlobalEnv import rcEnv
 
 
+@pytest.fixture(scope='function')
+def loop_forever(mocker):
+    return mocker.patch.object(osvcd.Daemon, 'loop_forever')
+
+
 @pytest.mark.ci
 @pytest.mark.usefixtures('osvc_path_tests')
 class TestDaemonRun:
@@ -56,4 +61,32 @@ class TestDaemonRun:
             pid_file.write('1')
         mock_argv(['--debug', '-f'])
         osvcd.main()
+        assert loop_forever.call_count == 1
+
+    @staticmethod
+    def test_refuse_to_run_when_another_daemon_process_is_running_with_non_same_pid_as_us(
+            mocker,
+            mock_argv,
+            loop_forever):
+        mocker.patch('osvcd.daemon_process_running', return_value=True)
+        mocker.patch('osvcd.os.getpid', return_value=799)
+        # write daemon signature with another pid
+        osvcd.Daemon().write_pid()
+        # ensure testing pid is not another pid
+        mocker.patch('osvcd.os.getpid', return_value=790)
+
+        with pytest.raises(SystemExit) as error:
+            mock_argv(['--debug', '-f'])
+            osvcd.main()
+        assert loop_forever.call_count == 0
+        assert error.value.code == 1
+
+    @staticmethod
+    def test_run_loop_forever_when_we_are_detected_daemon(mock_argv, loop_forever):
+        # write same as us signature
+        osvcd.Daemon().write_pid()
+
+        mock_argv(['--debug', '-f'])
+        osvcd.main()
+
         assert loop_forever.call_count == 1


### PR DESCRIPTION
…evious one)

During daemon startup, it verify if anothoer daemon is running to avoid double daemon run.
But it is possible that current daemon pid is same as previous one.

We now detect this situation and allow start daemon.

backport of b2.1