### PR TITLE
Fix Solaris10 which command bad behaviour

### DIFF
--- a/bin/pkg/make_sunos_pkg
+++ b/bin/pkg/make_sunos_pkg
@@ -154,7 +154,7 @@ cd $REPODIR
 
 cat > $REPODIR/postinstall <<EOF
 #!/sbin/sh
-which python3 > /dev/null 2>&1 && PYTHON=python3 || PYTHON=python
+type python3 > /dev/null 2>&1 && PYTHON=python3 || PYTHON=python
 su root -c "PATH=\${PKG_INSTALL_ROOT}/usr/local/bin:$PATH:/usr/sfw/bin:/usr/local/bin \$PYTHON \${PKG_INSTALL_ROOT}$BASE/usr/share/opensvc/bin/postinstall"
 EOF
 


### PR DESCRIPTION
    # which python3
    no python3 in /sbin /usr/sbin /usr/bin /usr/sadm/install/bin
    # echo $?
    0