### PR TITLE
Add a non-leader provisioner to docker/podman resources

### DIFF
--- a/opensvc/drivers/resource/container/docker/__init__.py
+++ b/opensvc/drivers/resource/container/docker/__init__.py
@@ -894,6 +894,10 @@ class ContainerDocker(BaseContainer):
         super(ContainerDocker, self).unprovision()
         self.container_rm()
 
+    def provisioner_shared_non_leader(self):
+        if not self.lib.docker_daemon_private:
+            self.image_pull()
+
     def start(self):
         if self.image_pull_policy == "always":
             self.image_pull()


### PR DESCRIPTION
This provisioner method pre-pull the image on non leader nodes if the
docker_daemon_private=false (default).