### PR TITLE
Add more tests on monitor do()

### DIFF
--- a/opensvc/tests/daemon/monitor/test_orchestrator_start.py
+++ b/opensvc/tests/daemon/monitor/test_orchestrator_start.py
@@ -102,28 +102,33 @@ def mock_daemon(mocker, osvc_path_tests):
     shared.DAEMON = Daemon()
 
 
-def assert_nmon_status(monitor, status, message='reason'):
-    monitor.log.info('==> assert monitor status is "%s" (reason: %s), full value is %s',
-                     status, message, json.dumps(shared.NMON_DATA))
+def assert_nmon_status(log_info, status, message='reason'):
+    log_info('COMMENT: ASSERT monitor status is "%s" (reason: %s), full value is %s',
+             status, message, json.dumps(shared.NMON_DATA))
     assert shared.NMON_DATA['status'] == status
 
 
-def assert_smon_status(monitor, svcname, status, message='reason'):
-    monitor.log.info('==> assert smon status for svc %s is "%s" (reason: %s), full value is %s',
-                     svcname, status, message, json.dumps(shared.SMON_DATA[svcname]))
+def assert_smon_status(log_info, svcname, status, message='reason'):
+    log_info('COMMENT: ASSERT smon status for svc %s is "%s" (reason: %s), full value is %s',
+             svcname, status, message, json.dumps(shared.SMON_DATA[svcname]))
     assert shared.SMON_DATA[svcname]['status'] == status
 
 
-def assert_smon_local_expect(monitor, svcname, local_expect, message='reason'):
-    monitor.log.info('==> assert smon local_expect for svc %s is "%s" (reason: %s), full value is %s',
-                     svcname, local_expect, message, json.dumps(shared.SMON_DATA[svcname]))
+def assert_smon_local_expect(log_info, svcname, local_expect, message='reason'):
+    log_info('COMMENT: ASSERT smon local_expect for svc %s is "%s" (reason: %s), full value is %s',
+             svcname, local_expect, message, json.dumps(shared.SMON_DATA[svcname]))
     assert shared.SMON_DATA[svcname]['local_expect'] == local_expect
 
 
-def assert_command_has_been_launched(monitor, call_list, call_args_list):
+def assert_command_has_been_launched(log_info, call_list, call_args_list):
     for call in call_list:
-        monitor.log.info('==> assert call %s has been called', call)
+        log_info('COMMENT: ASSERT call %s has been called', call)
         assert call in call_args_list
+
+def assert_command_has_not_been_launched(log_info, call_list, call_args_list):
+    for call in call_list:
+        log_info('COMMENT: ASSERT call %s has not been called', call)
+        assert call not in call_args_list
 
 
 @pytest.mark.ci
@@ -136,7 +141,7 @@ class TestMonitorOrchestratorStart(object):
     @pytest.mark.parametrize(
         'title, svcnames, svcname, other_node_status, transition_status1, transition_status2, final_status',
         [
-            ("parent avail - but start failed",
+            ("parent avail - /has start/, /start failed/",
              ['parent', ],
              's-depend-on-parent',
              {
@@ -147,7 +152,18 @@ class TestMonitorOrchestratorStart(object):
              },
              'ready', 'starting', 'start failed'),
 
-            ("simple parent avail - will start",
+            ("local frozen, simple parent avail - stay idle, /no start/",
+             ['parent', ],
+             's-depend-on-parent',
+             {
+                 "parent": {"avail": "up", "overall": "up", "updated": time.time(), "topology": "failover",
+                            "monitor": {"status": "up", "overall": "up"}},
+                 "s-depend-on-parent": {"avail": "down", "overall": "down", "updated": time.time(), # "frozen": time.time(),
+                                        "topology": "failover", "monitor": {"status": "down", "overall": "down"}}
+             },
+             'idle', 'idle', 'idle'),
+
+            ("simple parent avail - /has start/",
              ['parent', ],
              's-depend-on-parent',
              {
@@ -158,7 +174,7 @@ class TestMonitorOrchestratorStart(object):
              },
              'ready', 'starting', 'idle'),
 
-            ("parent avail unknown - stay in wait parents",
+            ("parent avail unknown - stay in wait parents /no start/",
              ['parent', ],
              's-depend-on-parent',
              {
@@ -170,17 +186,18 @@ class TestMonitorOrchestratorStart(object):
              },
              'wait parents', 'wait parents', 'wait parents'),
 
-            ("no parent remote status, must stay in wait parent",
+            ("/no node2 status/, plop must stay in wait parent, /no start/, /node frozen/",
              ['parent', ],
              's-depend-on-parent',
              {
+                 "parent": {"avail": "unknown", "overall": "unknown", "updated": time.time(),
+                            "topology": "failover", "monitor": {"status": "unknown", "overall": "unknown"}},
                  "s-depend-on-parent": {"avail": "down", "overall": "down", "updated": time.time(),
                                         "topology": "failover", "monitor": {"status": "down", "overall": "down"}}
              },
-             # Should be 'wait parents', 'wait parents', 'wait parents'
-             'ready', 'starting', 'idle'),
+             'idle', 'idle', 'idle'),
 
-            ("not enough flex - stay in wait parents",
+            ("not enough flex - stay in wait parents, /no start/",
              ['parent-flex-min-2', ],
              's-depend-on-parent-flex-min-2',
              {
@@ -192,7 +209,7 @@ class TestMonitorOrchestratorStart(object):
              },
              'wait parents', 'wait parents', 'wait parents'),
 
-            ("enough flex instances - will start",
+            ("enough flex instances - will start, /has start/",
              ['parent-flex-min-1', ],
              's-depend-on-parent-flex-min-1',
              {
@@ -204,7 +221,7 @@ class TestMonitorOrchestratorStart(object):
              },
              'ready', 'starting', 'idle'),
 
-            ("local parent not avail - stay in wait parents",
+            ("local parent not avail - stay in wait parents, /no start/",
              ['parent', ],
              's-depend-on-local-parent',
              {
@@ -214,8 +231,19 @@ class TestMonitorOrchestratorStart(object):
                                               "topology": "failover", "monitor": {"status": "down", "overall": "down"}}
              },
              'wait parents', 'wait parents', 'wait parents'),
+
+            ("local parent is avail - will start, /has start/",
+             ['parent', ],
+             's-depend-on-local-parent',
+             {
+                 "parent": {"avail": "up", "overall": "up", "updated": time.time(), "topology": "failover",
+                            "monitor": {"status": "up", "overall": "up"}},
+                 "s-depend-on-local-parent": {"avail": "down", "overall": "down", "updated": time.time(),
+                                              "topology": "failover", "monitor": {"status": "down", "overall": "down"}}
+             },
+             'ready', 'starting', 'idle'),
         ])
-    def test_flex_service_has_correct_return_value(
+    def test_orchestrator_from_init_to_run_loop(
             mocker,
             title,
             svcnames,
@@ -231,51 +259,69 @@ class TestMonitorOrchestratorStart(object):
             execs["service_command_exe"] = cmd
 
         def service_command_mock(*args, **kwargs):
-            monitor.log.info('calling service_command(%s, %s)' % (args, kwargs))
+            log_comment('detect mock service_command(%s, %s)' % (args, kwargs))
             return Popen(execs["service_command_exe"])
 
-        pathetc = env.Env.paths.pathetc
+        def log_comment(*args, **kwargs):
+             if monitor and getattr(monitor, 'log'):
+                 monitor.log.info(*args, **kwargs)
+             else:
+                 shared.NODE.log.info(*args, **kwargs)
 
-        for s in svcnames + [svcname]:
+        def create_svc_config(s):
+            pathetc = env.Env.paths.pathetc
             if not os.path.exists(pathetc):
                 os.mkdir(pathetc)
             with open(os.path.join(pathetc, '%s.conf' % s), mode='w+') as svc_file:
                 svc_file.write(SERVICES[s])
+            log_comment('COMMENT: created %s service with config \n%s\n', s, SERVICES[s])
 
         service_command = mocker.patch.object(Monitor, 'service_command', side_effect=service_command_mock)
-        monitor_node2 = deepcopy(shared.NMON_DATA)
-        monitor_node2["status"] = "idle"
-        shared.CLUSTER_DATA["node2"] = {
-            "compat": shared.COMPAT_VERSION,
-            "api": shared.API_VERSION,
-            "agent": shared.NODE.agent_version,
-            "monitor": monitor_node2,
-            "labels": shared.NODE.labels,
-            "targets": shared.NODE.targets,
-            "services": {"status": {k: v for k, v in other_node_status.items()},  "monitor": {"status": "up"}, }
-        }
+        monitor = Monitor()
+
+        if '/no node2 status/' not in title:
+            monitor_node2 = deepcopy(shared.NMON_DATA)
+            monitor_node2["status"] = "idle"
+            shared.CLUSTER_DATA["node2"] = {
+                "compat": shared.COMPAT_VERSION,
+                "api": shared.API_VERSION,
+                "agent": shared.NODE.agent_version,
+                "monitor": monitor_node2,
+                "labels": shared.NODE.labels,
+                "targets": shared.NODE.targets,
+                "services": {"status": {k: v for k, v in other_node_status.items()},  "monitor": {"status": "up"}, }
+            }
+        else:
+            log_comment('COMMENT: hack rejoin_grace_period to 0.001')
+            monitor._lazy_rejoin_grace_period = 0.001
 
         def do():
-            monitor.log.info('\n==> monitor.do()')
+            log_comment('\nCOMMENT: monitor.do()')
             monitor.do()
-            monitor.log.info('proc ps count = %s', len(monitor.procs))
+            log_comment('COMMENT: proc ps count = %s', len(monitor.procs))
 
-        monitor = Monitor()
-        shared.NODE.log.info('starting test for %s', title)
+        log_comment('\n===============================')
+        log_comment('COMMENT: starting test for %s', title)
+        log_comment('COMMENT: audited service "%s" expected transition 1: %s, 2: %s, final: %s',
+                    svcname, transition_status1, transition_status2, final_status)
+        create_svc_config(svcname)
+        log_comment('COMMENT: other services')
+        for s in svcnames:
+            create_svc_config(s)
         monitor._lazy_cluster_nodes = [env.Env.nodename, "node2"]
 
-        shared.NODE.log.info('\n==> monitor.init()')
+        log_comment('COMMENT: monitor.init()')
         monitor.init()
-        assert_nmon_status(monitor, 'init', 'after init()')
-        monitor.log.info('==> asserting all services are refreshed: (service_command.call_args_list is correct: %s)',
-                         service_command.call_args_list[0])
+        assert_nmon_status(log_comment, 'init', 'after init()')
+        log_comment('COMMENT: asserting all services are refreshed: (service_command.call_args_list is correct: %s)',
+                    service_command.call_args_list[0])
         assert service_command.call_count == 1
         for s in svcnames + [svcname, 'cluster']:
             assert s in service_command.call_args_list[0][0][0].split(',')
         assert service_command.call_args_list[0][0][1] == ['status', '--parallel', '--refresh']
         assert service_command.call_args_list[0][1] == {"local": False}
 
-        monitor.log.info('==> create ccfg/cluster status.json')
+        log_comment('COMMENT: create ccfg/cluster status.json')
         if not os.path.exists(svc_pathvar("ccfg/cluster")):
             os.makedirs(svc_pathvar("ccfg/cluster"))
         open(svc_pathvar("ccfg/cluster", "status.json"), 'w').\
@@ -283,48 +329,79 @@ class TestMonitorOrchestratorStart(object):
 
         for i in range(3):
             do()
-            assert_nmon_status(monitor, 'init', 'after do(), when status.json not yet present')
+            assert_nmon_status(log_comment, 'init', 'after do(), when all status.json not yet present')
+
+        for s in svcnames + [svcname]:
+            do()
+            assert_nmon_status(log_comment, 'init', 'after do(), when all status.json not yet present')
+            if "local parent is avail" in title and s in svcnames:
+                avail = "up"
+            else:
+                avail = "down"
+            if 'local frozen' in title and s == svcname:
+                frozen = time.time()
+                log_comment('COMMENT: create frozen flag for %s', s)
+                open(svc_pathvar(s, "frozen"), 'w').close()
+            else:
+                frozen = 0
+            log_comment('COMMENT: create local status.json for %s with avail: %s', s, avail)
+            status = deepcopy(other_node_status.get(s, {}))
+            status['avail'] = avail
+            status['updated'] = time.time()
+            status['monitor'] = {}
+            status['frozen'] = frozen
+            open(svc_pathvar(s, "status.json"), 'w').write(json.dumps(status))
 
         svc = monitor.get_service(svcname)
         assert svc
 
-        for svcname in svcnames + [svcname]:
-            monitor.log.info('=> create status.json for %s with avail: down', svcname)
-            status = deepcopy(other_node_status.get(svcname, {}))
-            status['avail'] = "down"
-            status['updated'] = time.time()
-            status['monitor'] = {}
-            open(svc_pathvar(svcname, "status.json"), 'w').write(json.dumps(status))
-
+        time.sleep(0.001)
         do()
-        assert_nmon_status(monitor, 'idle', 'after status.json created')
-        assert_smon_status(monitor, svcname, transition_status1)
+        assert_nmon_status(log_comment, 'idle', 'after status.json created')
+        assert_smon_status(log_comment, svcname, transition_status1)
 
-        monitor.log.info('set ready period to 0.00000001')
-        monitor._lazy_ready_period = 0.00000001
-        if 'start failed' in title:
-            monitor.log.info('set service command mock to %s', env.Env.syspaths.false)
+        log_comment('COMMENT: hack ready_period to 0.001')
+        monitor._lazy_ready_period = 0.001
+        time.sleep(0.001)
+
+        if "/start failed/" in title:
+            log_comment('COMMENT: hack service command mock to %s', env.Env.syspaths.false)
             set_service_command_cmd(env.Env.syspaths.false)
         do()
-        assert_smon_status(monitor, svcname, transition_status2)
-        if 'start failed' in title:
-            assert_command_has_been_launched(monitor, [((svcname, ['start']), {}), ], service_command.call_args_list)
-        elif 'starting' in transition_status2:
-            assert_command_has_been_launched(monitor, [((svcname, ['start']), {}), ], service_command.call_args_list)
-            for svcname in [svcname]:
-                monitor.log.info('=> create status.json for %s with avail up', svcname)
-                status = deepcopy(other_node_status[svcname])
-                status['avail'] = "up"
-                status['updated'] = time.time()
-                open(svc_pathvar(svcname, "status.json"), 'w').write(json.dumps(status))
+        assert_smon_status(log_comment, svcname, transition_status2)
+
+        if "/has start/" in title:
+            assert_command_has_been_launched(log_comment, [((svcname, ['start']), {}), ], service_command.call_args_list)
+            if "/start failed/" not in title:
+                for svcname in [svcname]:
+                    log_comment('COMMENT: create status.json for %s with avail up', svcname)
+                    status = deepcopy(other_node_status[svcname])
+                    status['avail'] = "up"
+                    status['updated'] = time.time()
+                    open(svc_pathvar(svcname, "status.json"), 'w').write(json.dumps(status))
         else:
             assert ((svcname, ['start']), {}) not in service_command.call_args_list
 
         do()
-        assert_smon_status(monitor, svcname, final_status)
+        assert_smon_status(log_comment, svcname, final_status)
 
         for i in range(3):
             do()
-            assert_smon_status(monitor, svcname, final_status)
-            if 'idle' in final_status:
-                assert_smon_local_expect(monitor, svcname, 'started')
+            assert_smon_status(log_comment, svcname, final_status)
+            if '/no start/' in title:
+                assert_command_has_not_been_launched(
+                    log_comment,
+                    [((svcname, ['start']), {}), ],
+                    service_command.call_args_list)
+            if '/has start/' in title:
+                assert_command_has_been_launched(
+                    log_comment,
+                    [((svcname, ['start']), {}), ],
+                    service_command.call_args_list)
+                if "/start failed/" not in title:
+                    assert_smon_local_expect(log_comment, svcname, 'started')
+
+        if "/node frozen/" in title:
+            assert monitor.node_frozen > 0
+        else:
+            assert monitor.node_frozen == 0


### PR DESCRIPTION
test_orchestrator_from_init_to_run_loop:
o [parent avail - /has start/, /start failed/-svcnames0-s-depend-on-parent-other_node_status0-ready-starting-start failed]
o [local frozen, simple parent avail - stay idle, /no start/-svcnames1-s-depend-on-parent-other_node_status1-idle-idle-idle]
o [simple parent avail - /has start/-svcnames2-s-depend-on-parent-other_node_status2-ready-starting-idle]
o [parent avail unknown - stay in wait parents /no start/-svcnames3-s-depend-on-parent-other_node_status3-wait parents-wait parents-wait parents]
o [/no node2 status/, plop must stay in wait parent, /no start/, /node frozen/-svcnames4-s-depend-on-parent-other_node_status4-idle-idle-idle]
o [not enough flex - stay in wait parents, /no start/-svcnames5-s-depend-on-parent-flex-min-2-other_node_status5-wait parents-wait parents-wait parents]
o [enough flex instances - will start, /has start/-svcnames6-s-depend-on-parent-flex-min-1-other_node_status6-ready-starting-idle]
o [local parent not avail - stay in wait parents, /no start/-svcnames7-s-depend-on-local-parent-other_node_status7-wait parents-wait parents-wait parents]
o [local parent is avail - will start, /has start/-svcnames8-s-depend-on-local-parent-other_node_status8-ready-starting-idle]

log:

===============================
  COMMENT: starting test for parent avail - /has start/, /start failed/
  COMMENT: audited service "s-depend-on-parent" expected transition 1: ready, 2: starting, final: start failed
  COMMENT: created s-depend-on-parent service with config
[DEFAULT]
id = 37d188ce-4ce6-44ea-aa56-ac38aabb606e
nodes = *
parents = parent
orchestrate = ha

  COMMENT: other services
  COMMENT: created parent service with config

[DEFAULT]
id = 0b074e97-17cb-4970-b0b9-6b8a0b025e16
nodes = *

  COMMENT: monitor.init()
@ n:localnode c:monitor
  monitor started
  boot id 1605202131.42, last None
  detect mock service_command(('parent,s-depend-on-parent,cluster', ['status', '--parallel', '--refresh']), {'local': False})
  /private/tmp/pytest.opensvc/test_orchestrator_from_init_to0/var/nodes_info.json updated
  COMMENT: ASSERT monitor status is "init" (reason: after init()), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: asserting all services are refreshed: (service_command.call_args_list is correct: call('parent,s-depend-on-parent,cluster', ['status', '--parallel', '--refresh'], local=False))
  COMMENT: create ccfg/cluster status.json

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for parent with avail: down

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for s-depend-on-parent with avail: down

COMMENT: monitor.do()
  node monitor status change: init => rejoin
  end of rejoin grace period: now rejoined
  node monitor status change: rejoin => idle
  we have the highest 'nodes order' placement priority for failover service s-depend-on-parent
  service s-depend-on-parent parents all avail up
  failover service s-depend-on-parent status down
  service s-depend-on-parent monitor status change: idle => ready
  COMMENT: proc ps count = 0
  COMMENT: ASSERT monitor status is "idle" (reason: after status.json created), full value is {"status": "idle", "global_expect_updated": 1605202131.860467, "status_updated": 1605202131.860467}
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "ready" (reason: reason), full value is {"status": "ready", "global_expect_updated": 1605202131.839138, "status_updated": 1605202131.862373}
  COMMENT: hack ready_period to 0.001
  COMMENT: hack service command mock to /usr/bin/false

COMMENT: monitor.do()
  service s-depend-on-parent start failover down instance ready for 0 seconds
@ n:localnode o:s-depend-on-parent sc:n
  start failover down instance ready for 0 seconds
  service s-depend-on-parent monitor status change: ready => starting
  detect mock service_command(('s-depend-on-parent', ['start']), {})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "starting" (reason: reason), full value is {"status": "starting", "global_expect_updated": 1605202131.839138, "status_updated": 1605202131.867951}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has been called

COMMENT: monitor.do()
  service s-depend-on-parent monitor status change: starting => start failed
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "start failed" (reason: reason), full value is {"status": "start failed", "global_expect_updated": 1605202131.839138, "status_updated": 1605202131.873346}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "start failed" (reason: reason), full value is {"status": "start failed", "global_expect_updated": 1605202131.839138, "status_updated": 1605202131.873346}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has been called

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "start failed" (reason: reason), full value is {"status": "start failed", "global_expect_updated": 1605202131.839138, "status_updated": 1605202131.873346}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has been called

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "start failed" (reason: reason), full value is {"status": "start failed", "global_expect_updated": 1605202131.839138, "status_updated": 1605202131.873346}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has been called
PASSED [ 22%]@ n:localnode

===============================
  COMMENT: starting test for local frozen, simple parent avail - stay idle, /no start/
  COMMENT: audited service "s-depend-on-parent" expected transition 1: idle, 2: idle, final: idle
  COMMENT: created s-depend-on-parent service with config
[DEFAULT]
id = 37d188ce-4ce6-44ea-aa56-ac38aabb606e
nodes = *
parents = parent
orchestrate = ha

  COMMENT: other services
  COMMENT: created parent service with config

[DEFAULT]
id = 0b074e97-17cb-4970-b0b9-6b8a0b025e16
nodes = *

  COMMENT: monitor.init()
@ n:localnode c:monitor
  monitor started
  boot id 1605202131.42, last None
  detect mock service_command(('parent,s-depend-on-parent,cluster', ['status', '--parallel', '--refresh']), {'local': False})
  /private/tmp/pytest.opensvc/test_orchestrator_from_init_to1/var/nodes_info.json updated
  COMMENT: ASSERT monitor status is "init" (reason: after init()), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: asserting all services are refreshed: (service_command.call_args_list is correct: call('parent,s-depend-on-parent,cluster', ['status', '--parallel', '--refresh'], local=False))
  COMMENT: create ccfg/cluster status.json

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for parent with avail: down

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create frozen flag for s-depend-on-parent
  COMMENT: create local status.json for s-depend-on-parent with avail: down

COMMENT: monitor.do()
  node monitor status change: init => rejoin
  end of rejoin grace period: now rejoined
  node monitor status change: rejoin => idle
  COMMENT: proc ps count = 0
  COMMENT: ASSERT monitor status is "idle" (reason: after status.json created), full value is {"status": "idle", "global_expect_updated": 1605202132.236635, "status_updated": 1605202132.236635}
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202132.211753, "status_updated": 1605202132.211753}
  COMMENT: hack ready_period to 0.001

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202132.211753, "status_updated": 1605202132.211753}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202132.211753, "status_updated": 1605202132.211753}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202132.211753, "status_updated": 1605202132.211753}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has not been called

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202132.211753, "status_updated": 1605202132.211753}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has not been called

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202132.211753, "status_updated": 1605202132.211753}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has not been called
PASSED [ 33%]@ n:localnode

===============================
  COMMENT: starting test for simple parent avail - /has start/
  COMMENT: audited service "s-depend-on-parent" expected transition 1: ready, 2: starting, final: idle
  COMMENT: created s-depend-on-parent service with config
[DEFAULT]
id = 37d188ce-4ce6-44ea-aa56-ac38aabb606e
nodes = *
parents = parent
orchestrate = ha

  COMMENT: other services
  COMMENT: created parent service with config

[DEFAULT]
id = 0b074e97-17cb-4970-b0b9-6b8a0b025e16
nodes = *

  COMMENT: monitor.init()
@ n:localnode c:monitor
  monitor started
  boot id 1605202131.42, last None
  detect mock service_command(('parent,s-depend-on-parent,cluster', ['status', '--parallel', '--refresh']), {'local': False})
  /private/tmp/pytest.opensvc/test_orchestrator_from_init_to2/var/nodes_info.json updated
  COMMENT: ASSERT monitor status is "init" (reason: after init()), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: asserting all services are refreshed: (service_command.call_args_list is correct: call('parent,s-depend-on-parent,cluster', ['status', '--parallel', '--refresh'], local=False))
  COMMENT: create ccfg/cluster status.json

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for parent with avail: down

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for s-depend-on-parent with avail: down

COMMENT: monitor.do()
  node monitor status change: init => rejoin
  end of rejoin grace period: now rejoined
  node monitor status change: rejoin => idle
  we have the highest 'nodes order' placement priority for failover service s-depend-on-parent
  service s-depend-on-parent parents all avail up
  failover service s-depend-on-parent status down
  service s-depend-on-parent monitor status change: idle => ready
  COMMENT: proc ps count = 0
  COMMENT: ASSERT monitor status is "idle" (reason: after status.json created), full value is {"status": "idle", "global_expect_updated": 1605202132.652283, "status_updated": 1605202132.652283}
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "ready" (reason: reason), full value is {"status": "ready", "global_expect_updated": 1605202132.628545, "status_updated": 1605202132.654248}
  COMMENT: hack ready_period to 0.001

COMMENT: monitor.do()
  service s-depend-on-parent start failover down instance ready for 0 seconds
  start failover down instance ready for 0 seconds
  service s-depend-on-parent monitor status change: ready => starting
  detect mock service_command(('s-depend-on-parent', ['start']), {})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "starting" (reason: reason), full value is {"status": "starting", "global_expect_updated": 1605202132.628545, "status_updated": 1605202132.65938}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has been called
  COMMENT: create status.json for s-depend-on-parent with avail up

COMMENT: monitor.do()
  service s-depend-on-parent monitor status change: starting => idle
  service s-depend-on-parent monitor local expect change: none => started
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202132.628545, "local_expect": "started", "status_updated": 1605202132.665302}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202132.628545, "local_expect": "started", "status_updated": 1605202132.665302}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has been called
  COMMENT: ASSERT smon local_expect for svc s-depend-on-parent is "started" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202132.628545, "local_expect": "started", "status_updated": 1605202132.665302}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202132.628545, "local_expect": "started", "status_updated": 1605202132.665302}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has been called
  COMMENT: ASSERT smon local_expect for svc s-depend-on-parent is "started" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202132.628545, "local_expect": "started", "status_updated": 1605202132.665302}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202132.628545, "local_expect": "started", "status_updated": 1605202132.665302}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has been called
  COMMENT: ASSERT smon local_expect for svc s-depend-on-parent is "started" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202132.628545, "local_expect": "started", "status_updated": 1605202132.665302}
PASSED [ 44%]@ n:localnode

===============================
  COMMENT: starting test for parent avail unknown - stay in wait parents /no start/
  COMMENT: audited service "s-depend-on-parent" expected transition 1: wait parents, 2: wait parents, final: wait parents
  COMMENT: created s-depend-on-parent service with config
[DEFAULT]
id = 37d188ce-4ce6-44ea-aa56-ac38aabb606e
nodes = *
parents = parent
orchestrate = ha

  COMMENT: other services
  COMMENT: created parent service with config

[DEFAULT]
id = 0b074e97-17cb-4970-b0b9-6b8a0b025e16
nodes = *

  COMMENT: monitor.init()
@ n:localnode c:monitor
  monitor started
  boot id 1605202131.42, last None
  detect mock service_command(('parent,s-depend-on-parent,cluster', ['status', '--parallel', '--refresh']), {'local': False})
  /private/tmp/pytest.opensvc/test_orchestrator_from_init_to3/var/nodes_info.json updated
  COMMENT: ASSERT monitor status is "init" (reason: after init()), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: asserting all services are refreshed: (service_command.call_args_list is correct: call('parent,s-depend-on-parent,cluster', ['status', '--parallel', '--refresh'], local=False))
  COMMENT: create ccfg/cluster status.json

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for parent with avail: down

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for s-depend-on-parent with avail: down

COMMENT: monitor.do()
  node monitor status change: init => rejoin
  end of rejoin grace period: now rejoined
  node monitor status change: rejoin => idle
  we have the highest 'nodes order' placement priority for failover service s-depend-on-parent
  service s-depend-on-parent parents not available: parent
  service s-depend-on-parent monitor status change: idle => wait parents
  COMMENT: proc ps count = 0
  COMMENT: ASSERT monitor status is "idle" (reason: after status.json created), full value is {"status": "idle", "global_expect_updated": 1605202133.091206, "status_updated": 1605202133.091205}
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202133.068768, "status_updated": 1605202133.092766}
  COMMENT: hack ready_period to 0.001

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202133.068768, "status_updated": 1605202133.092766}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202133.068768, "status_updated": 1605202133.092766}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202133.068768, "status_updated": 1605202133.092766}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has not been called

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202133.068768, "status_updated": 1605202133.092766}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has not been called

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202133.068768, "status_updated": 1605202133.092766}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has not been called
PASSED [ 55%]@ n:localnode
  COMMENT: hack rejoin_grace_period to 0.001

===============================
  COMMENT: starting test for /no node2 status/, plop must stay in wait parent, /no start/, /node frozen/
  COMMENT: audited service "s-depend-on-parent" expected transition 1: idle, 2: idle, final: idle
  COMMENT: created s-depend-on-parent service with config
[DEFAULT]
id = 37d188ce-4ce6-44ea-aa56-ac38aabb606e
nodes = *
parents = parent
orchestrate = ha

  COMMENT: other services
  COMMENT: created parent service with config

[DEFAULT]
id = 0b074e97-17cb-4970-b0b9-6b8a0b025e16
nodes = *

  COMMENT: monitor.init()
@ n:localnode c:monitor
  monitor started
  boot id 1605202131.42, last None
  detect mock service_command(('parent,s-depend-on-parent,cluster', ['status', '--parallel', '--refresh']), {'local': False})
  /private/tmp/pytest.opensvc/test_orchestrator_from_init_to4/var/nodes_info.json updated
  COMMENT: ASSERT monitor status is "init" (reason: after init()), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: asserting all services are refreshed: (service_command.call_args_list is correct: call('parent,s-depend-on-parent,cluster', ['status', '--parallel', '--refresh'], local=False))
  COMMENT: create ccfg/cluster status.json

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for parent with avail: down

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for s-depend-on-parent with avail: down

COMMENT: monitor.do()
  node monitor status change: init => rejoin
  end of rejoin grace period: expired, but some nodes are still unreacheable. freeze node.
  node monitor status change: rejoin => idle
  freeze node, the cluster is not complete on rejoin grace period expiration
  COMMENT: proc ps count = 0
  COMMENT: ASSERT monitor status is "idle" (reason: after status.json created), full value is {"status": "idle", "global_expect_updated": 1605202133.463139, "status_updated": 1605202133.463139}
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202133.439936, "status_updated": 1605202133.439936}
  COMMENT: hack ready_period to 0.001

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202133.439936, "status_updated": 1605202133.439936}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202133.439936, "status_updated": 1605202133.439936}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202133.439936, "status_updated": 1605202133.439936}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has not been called

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202133.439936, "status_updated": 1605202133.439936}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has not been called

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202133.439936, "status_updated": 1605202133.439936}
  COMMENT: ASSERT call (('s-depend-on-parent', ['start']), {}) has not been called
PASSED [ 66%]@ n:localnode

===============================
  COMMENT: starting test for not enough flex - stay in wait parents, /no start/
  COMMENT: audited service "s-depend-on-parent-flex-min-2" expected transition 1: wait parents, 2: wait parents, final: wait parents
  COMMENT: created s-depend-on-parent-flex-min-2 service with config
[DEFAULT]
id = a7358b74-5a31-40c9-91cd-28839b7ef96e
nodes = *
parents = parent-flex-min-2
orchestrate = ha

  COMMENT: other services
  COMMENT: created parent-flex-min-2 service with config

[DEFAULT]
id = b5d08e0f-a724-4e08-bfd4-0de7ce0ed890
nodes = *
topology = flex
orchestrate = ha
flex_min = 2

  COMMENT: monitor.init()
@ n:localnode c:monitor
  monitor started
  boot id 1605202131.42, last None
  detect mock service_command(('s-depend-on-parent-flex-min-2,parent-flex-min-2,cluster', ['status', '--parallel', '--refresh']), {'local': False})
  /private/tmp/pytest.opensvc/test_orchestrator_from_init_to5/var/nodes_info.json updated
  COMMENT: ASSERT monitor status is "init" (reason: after init()), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: asserting all services are refreshed: (service_command.call_args_list is correct: call('s-depend-on-parent-flex-min-2,parent-flex-min-2,cluster', ['status', '--parallel', '--refresh'], local=False))
  COMMENT: create ccfg/cluster status.json

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent-flex-min-2', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent-flex-min-2', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent-flex-min-2', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent-flex-min-2', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for parent-flex-min-2 with avail: down

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent-flex-min-2', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for s-depend-on-parent-flex-min-2 with avail: down

COMMENT: monitor.do()
  node monitor status change: init => rejoin
  end of rejoin grace period: now rejoined
  node monitor status change: rejoin => idle
  we have the highest 'nodes order' placement priority for failover service s-depend-on-parent-flex-min-2
  service s-depend-on-parent-flex-min-2 parents not available: parent-flex-min-2
  service s-depend-on-parent-flex-min-2 monitor status change: idle => wait parents
  we have the 1/2 'nodes order' placement priority for flex service parent-flex-min-2
  flex service parent-flex-min-2 started, starting or ready to start instances: 1/2. local status down
  service parent-flex-min-2 monitor status change: idle => ready
  COMMENT: proc ps count = 0
  COMMENT: ASSERT monitor status is "idle" (reason: after status.json created), full value is {"status": "idle", "global_expect_updated": 1605202133.870762, "status_updated": 1605202133.870762}
  COMMENT: ASSERT smon status for svc s-depend-on-parent-flex-min-2 is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202133.844344, "status_updated": 1605202133.872321}
  COMMENT: hack ready_period to 0.001

COMMENT: monitor.do()
  service parent-flex-min-2 start flex down instance ready for 0.0040009021759 seconds
@ n:localnode o:parent-flex-min-2 sc:n
  start flex down instance ready for 0.0040009021759 seconds
  service parent-flex-min-2 monitor status change: ready => starting
  detect mock service_command(('parent-flex-min-2', ['start']), {})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT smon status for svc s-depend-on-parent-flex-min-2 is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202133.844344, "status_updated": 1605202133.872321}

COMMENT: monitor.do()
  service parent-flex-min-2 monitor status change: starting => idle
  service parent-flex-min-2 monitor local expect change: none => started
  flex service parent-flex-min-2 started, starting or ready to start instances: 1/2. local status down
  service parent-flex-min-2 monitor status change: idle => ready
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent-flex-min-2 is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202133.844344, "status_updated": 1605202133.872321}

COMMENT: monitor.do()
  service parent-flex-min-2 start flex down instance ready for 0.00215220451355 seconds
  start flex down instance ready for 0.00215220451355 seconds
  service parent-flex-min-2 monitor status change: ready => starting
  detect mock service_command(('parent-flex-min-2', ['start']), {})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT smon status for svc s-depend-on-parent-flex-min-2 is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202133.844344, "status_updated": 1605202133.872321}
  COMMENT: ASSERT call (('s-depend-on-parent-flex-min-2', ['start']), {}) has not been called

COMMENT: monitor.do()
  service parent-flex-min-2 monitor status change: starting => idle
  flex service parent-flex-min-2 started, starting or ready to start instances: 1/2. local status down
  service parent-flex-min-2 monitor status change: idle => ready
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent-flex-min-2 is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202133.844344, "status_updated": 1605202133.872321}
  COMMENT: ASSERT call (('s-depend-on-parent-flex-min-2', ['start']), {}) has not been called

COMMENT: monitor.do()
  service parent-flex-min-2 start flex down instance ready for 0.00224900245667 seconds
  start flex down instance ready for 0.00224900245667 seconds
  service parent-flex-min-2 monitor status change: ready => starting
  detect mock service_command(('parent-flex-min-2', ['start']), {})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT smon status for svc s-depend-on-parent-flex-min-2 is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202133.844344, "status_updated": 1605202133.872321}
  COMMENT: ASSERT call (('s-depend-on-parent-flex-min-2', ['start']), {}) has not been called
PASSED [ 77%]@ n:localnode

===============================
  COMMENT: starting test for enough flex instances - will start, /has start/
  COMMENT: audited service "s-depend-on-parent-flex-min-1" expected transition 1: ready, 2: starting, final: idle
  COMMENT: created s-depend-on-parent-flex-min-1 service with config
[DEFAULT]
id = b87d1237-3a15-46e1-baa8-6b8eb838b306
nodes = *
parents = parent-flex-min-1
orchestrate = ha

  COMMENT: other services
  COMMENT: created parent-flex-min-1 service with config

[DEFAULT]
id = 69803967-7c24-4d93-a752-f66a2f754805
nodes = *
topology = flex
orchestrate = ha
flex_min = 1

  COMMENT: monitor.init()
@ n:localnode c:monitor
  monitor started
  boot id 1605202131.42, last None
  detect mock service_command(('parent-flex-min-1,s-depend-on-parent-flex-min-1,cluster', ['status', '--parallel', '--refresh']), {'local': False})
  /private/tmp/pytest.opensvc/test_orchestrator_from_init_to6/var/nodes_info.json updated
  COMMENT: ASSERT monitor status is "init" (reason: after init()), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: asserting all services are refreshed: (service_command.call_args_list is correct: call('parent-flex-min-1,s-depend-on-parent-flex-min-1,cluster', ['status', '--parallel', '--refresh'], local=False))
  COMMENT: create ccfg/cluster status.json

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent-flex-min-1', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent-flex-min-1', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent-flex-min-1', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent-flex-min-1', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for parent-flex-min-1 with avail: down

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-parent-flex-min-1', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for s-depend-on-parent-flex-min-1 with avail: down

COMMENT: monitor.do()
  node monitor status change: init => rejoin
  end of rejoin grace period: now rejoined
  node monitor status change: rejoin => idle
  we have the highest 'nodes order' placement priority for failover service s-depend-on-parent-flex-min-1
  service s-depend-on-parent-flex-min-1 parents all avail up
  failover service s-depend-on-parent-flex-min-1 status down
  service s-depend-on-parent-flex-min-1 monitor status change: idle => ready
  COMMENT: proc ps count = 0
  COMMENT: ASSERT monitor status is "idle" (reason: after status.json created), full value is {"status": "idle", "global_expect_updated": 1605202134.314688, "status_updated": 1605202134.314688}
  COMMENT: ASSERT smon status for svc s-depend-on-parent-flex-min-1 is "ready" (reason: reason), full value is {"status": "ready", "global_expect_updated": 1605202134.288516, "status_updated": 1605202134.316366}
  COMMENT: hack ready_period to 0.001

COMMENT: monitor.do()
  service s-depend-on-parent-flex-min-1 start failover down instance ready for 0 seconds
@ n:localnode o:s-depend-on-parent-flex-min-1 sc:n
  start failover down instance ready for 0 seconds
  service s-depend-on-parent-flex-min-1 monitor status change: ready => starting
  detect mock service_command(('s-depend-on-parent-flex-min-1', ['start']), {})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT smon status for svc s-depend-on-parent-flex-min-1 is "starting" (reason: reason), full value is {"status": "starting", "global_expect_updated": 1605202134.288516, "status_updated": 1605202134.321982}
  COMMENT: ASSERT call (('s-depend-on-parent-flex-min-1', ['start']), {}) has been called
  COMMENT: create status.json for s-depend-on-parent-flex-min-1 with avail up

COMMENT: monitor.do()
  service s-depend-on-parent-flex-min-1 monitor status change: starting => idle
  service s-depend-on-parent-flex-min-1 monitor local expect change: none => started
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent-flex-min-1 is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202134.288516, "local_expect": "started", "status_updated": 1605202134.32749}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent-flex-min-1 is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202134.288516, "local_expect": "started", "status_updated": 1605202134.32749}
  COMMENT: ASSERT call (('s-depend-on-parent-flex-min-1', ['start']), {}) has been called
  COMMENT: ASSERT smon local_expect for svc s-depend-on-parent-flex-min-1 is "started" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202134.288516, "local_expect": "started", "status_updated": 1605202134.32749}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent-flex-min-1 is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202134.288516, "local_expect": "started", "status_updated": 1605202134.32749}
  COMMENT: ASSERT call (('s-depend-on-parent-flex-min-1', ['start']), {}) has been called
  COMMENT: ASSERT smon local_expect for svc s-depend-on-parent-flex-min-1 is "started" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202134.288516, "local_expect": "started", "status_updated": 1605202134.32749}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-parent-flex-min-1 is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202134.288516, "local_expect": "started", "status_updated": 1605202134.32749}
  COMMENT: ASSERT call (('s-depend-on-parent-flex-min-1', ['start']), {}) has been called
  COMMENT: ASSERT smon local_expect for svc s-depend-on-parent-flex-min-1 is "started" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202134.288516, "local_expect": "started", "status_updated": 1605202134.32749}
PASSED [ 88%]@ n:localnode

===============================
  COMMENT: starting test for local parent not avail - stay in wait parents, /no start/
  COMMENT: audited service "s-depend-on-local-parent" expected transition 1: wait parents, 2: wait parents, final: wait parents
  COMMENT: created s-depend-on-local-parent service with config
[DEFAULT]
id = aa16db07-a574-4b0c-b77a-2cd45a0b8701
nodes = *
parents = parent@{nodename}
orchestrate = ha

  COMMENT: other services
  COMMENT: created parent service with config

[DEFAULT]
id = 0b074e97-17cb-4970-b0b9-6b8a0b025e16
nodes = *

  COMMENT: monitor.init()
@ n:localnode c:monitor
  monitor started
  boot id 1605202131.42, last None
  detect mock service_command(('parent,s-depend-on-local-parent,cluster', ['status', '--parallel', '--refresh']), {'local': False})
  /private/tmp/pytest.opensvc/test_orchestrator_from_init_to7/var/nodes_info.json updated
  COMMENT: ASSERT monitor status is "init" (reason: after init()), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: asserting all services are refreshed: (service_command.call_args_list is correct: call('parent,s-depend-on-local-parent,cluster', ['status', '--parallel', '--refresh'], local=False))
  COMMENT: create ccfg/cluster status.json

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-local-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-local-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-local-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-local-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for parent with avail: down

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-local-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for s-depend-on-local-parent with avail: down

COMMENT: monitor.do()
  node monitor status change: init => rejoin
  end of rejoin grace period: now rejoined
  node monitor status change: rejoin => idle
  we have the highest 'nodes order' placement priority for failover service s-depend-on-local-parent
  service s-depend-on-local-parent parents not available: parent
  service s-depend-on-local-parent monitor status change: idle => wait parents
  COMMENT: proc ps count = 0
  COMMENT: ASSERT monitor status is "idle" (reason: after status.json created), full value is {"status": "idle", "global_expect_updated": 1605202134.68834, "status_updated": 1605202134.688339}
  COMMENT: ASSERT smon status for svc s-depend-on-local-parent is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202134.661605, "status_updated": 1605202134.689745}
  COMMENT: hack ready_period to 0.001

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-local-parent is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202134.661605, "status_updated": 1605202134.689745}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-local-parent is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202134.661605, "status_updated": 1605202134.689745}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-local-parent is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202134.661605, "status_updated": 1605202134.689745}
  COMMENT: ASSERT call (('s-depend-on-local-parent', ['start']), {}) has not been called

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-local-parent is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202134.661605, "status_updated": 1605202134.689745}
  COMMENT: ASSERT call (('s-depend-on-local-parent', ['start']), {}) has not been called

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-local-parent is "wait parents" (reason: reason), full value is {"status": "wait parents", "global_expect_updated": 1605202134.661605, "status_updated": 1605202134.689745}
  COMMENT: ASSERT call (('s-depend-on-local-parent', ['start']), {}) has not been called
PASSED [100%]@ n:localnode

===============================
  COMMENT: starting test for local parent is avail - will start, /has start/
  COMMENT: audited service "s-depend-on-local-parent" expected transition 1: ready, 2: starting, final: idle
  COMMENT: created s-depend-on-local-parent service with config
[DEFAULT]
id = aa16db07-a574-4b0c-b77a-2cd45a0b8701
nodes = *
parents = parent@{nodename}
orchestrate = ha

  COMMENT: other services
  COMMENT: created parent service with config

[DEFAULT]
id = 0b074e97-17cb-4970-b0b9-6b8a0b025e16
nodes = *

  COMMENT: monitor.init()
@ n:localnode c:monitor
  monitor started
  boot id 1605202131.42, last None
  detect mock service_command(('parent,s-depend-on-local-parent,cluster', ['status', '--parallel', '--refresh']), {'local': False})
  /private/tmp/pytest.opensvc/test_orchestrator_from_init_to8/var/nodes_info.json updated
  COMMENT: ASSERT monitor status is "init" (reason: after init()), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: asserting all services are refreshed: (service_command.call_args_list is correct: call('parent,s-depend-on-local-parent,cluster', ['status', '--parallel', '--refresh'], local=False))
  COMMENT: create ccfg/cluster status.json

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-local-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-local-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-local-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-local-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for parent with avail: up

COMMENT: monitor.do()
  detect mock service_command(('s-depend-on-local-parent', ['status', '--refresh', '--waitlock=0']), {'local': False})
  service parent monitor local_expect None => started
  COMMENT: proc ps count = 1
  COMMENT: ASSERT monitor status is "init" (reason: after do(), when all status.json not yet present), full value is {"status": "init", "status_updated": 1605202131.409847}
  COMMENT: create local status.json for s-depend-on-local-parent with avail: down

COMMENT: monitor.do()
  node monitor status change: init => rejoin
  end of rejoin grace period: now rejoined
  node monitor status change: rejoin => idle
  we have the highest 'nodes order' placement priority for failover service s-depend-on-local-parent
  service s-depend-on-local-parent parents all avail up
  failover service s-depend-on-local-parent status down
  service s-depend-on-local-parent monitor status change: idle => ready
  COMMENT: proc ps count = 0
  COMMENT: ASSERT monitor status is "idle" (reason: after status.json created), full value is {"status": "idle", "global_expect_updated": 1605202135.087362, "status_updated": 1605202135.087362}
  COMMENT: ASSERT smon status for svc s-depend-on-local-parent is "ready" (reason: reason), full value is {"status": "ready", "global_expect_updated": 1605202135.059293, "status_updated": 1605202135.089018}
  COMMENT: hack ready_period to 0.001

COMMENT: monitor.do()
  service s-depend-on-local-parent start failover down instance ready for 0 seconds
@ n:localnode o:s-depend-on-local-parent sc:n
  start failover down instance ready for 0 seconds
  service s-depend-on-local-parent monitor status change: ready => starting
  detect mock service_command(('s-depend-on-local-parent', ['start']), {})
  COMMENT: proc ps count = 1
  COMMENT: ASSERT smon status for svc s-depend-on-local-parent is "starting" (reason: reason), full value is {"status": "starting", "global_expect_updated": 1605202135.059293, "status_updated": 1605202135.094337}
  COMMENT: ASSERT call (('s-depend-on-local-parent', ['start']), {}) has been called
  COMMENT: create status.json for s-depend-on-local-parent with avail up

COMMENT: monitor.do()
  service s-depend-on-local-parent monitor status change: starting => idle
  service s-depend-on-local-parent monitor local expect change: none => started
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-local-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202135.059293, "local_expect": "started", "status_updated": 1605202135.099936}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-local-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202135.059293, "local_expect": "started", "status_updated": 1605202135.099936}
  COMMENT: ASSERT call (('s-depend-on-local-parent', ['start']), {}) has been called
  COMMENT: ASSERT smon local_expect for svc s-depend-on-local-parent is "started" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202135.059293, "local_expect": "started", "status_updated": 1605202135.099936}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-local-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202135.059293, "local_expect": "started", "status_updated": 1605202135.099936}
  COMMENT: ASSERT call (('s-depend-on-local-parent', ['start']), {}) has been called
  COMMENT: ASSERT smon local_expect for svc s-depend-on-local-parent is "started" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202135.059293, "local_expect": "started", "status_updated": 1605202135.099936}

COMMENT: monitor.do()
  COMMENT: proc ps count = 0
  COMMENT: ASSERT smon status for svc s-depend-on-local-parent is "idle" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202135.059293, "local_expect": "started", "status_updated": 1605202135.099936}
  COMMENT: ASSERT call (('s-depend-on-local-parent', ['start']), {}) has been called
  COMMENT: ASSERT smon local_expect for svc s-depend-on-local-parent is "started" (reason: reason), full value is {"status": "idle", "global_expect_updated": 1605202135.059293, "local_expect": "started", "status_updated": 1605202135.099936}