### PR TITLE
Fix driver array/hcs.py, action "list host groups"

### DIFF
--- a/opensvc/drivers/array/hcs.py
+++ b/opensvc/drivers/array/hcs.py
@@ -266,7 +266,7 @@ ACTIONS = {
         "list_ldevs": {
             "msg": "List configured extents",
         },
-        "list_hostgroups": {
+        "list_host_groups": {
             "msg": "List configured host groups",
         },
         "list_resource_groups": {


### PR DESCRIPTION
Typo in driver array/hcs.py, action list_host_groups cause "not implemented" result