### PR TITLE
Fix the volume provision action logs non written to file on the leade…

### DIFF
--- a/opensvc/drivers/resource/volume/__init__.py
+++ b/opensvc/drivers/resource/volume/__init__.py
@@ -603,6 +603,9 @@ class Volume(Resource):
 
         volume = factory("vol")(name=self.volname, namespace=self.svc.namespace, node=self.svc.node)
 
+        # force logger lazy eval now, to be sure its is configured non-volatile
+        volume.logger
+
         if volume.exists():
             self.log.info("volume %s already exists", self.volname)
             data = volume.print_status_data(mon_data=True)


### PR DESCRIPTION
…r node

We already cared about unconfiguring the volatile Vol logger, so the non
volatile Vol instanciated in the create_volume() codepath can reconfigure
its FileHandler.

But as we did not force a Vol::logger (a lazy) evaluation, we missed the
opportunity and the logger was configured again volatile.