### PR TITLE
Fix wrong "do <action> <option>" log

### DIFF
--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -970,7 +970,7 @@ class BaseSvc(Crypt, ExtConfigMixin):
             if self.node.oget("node", "dblog"):
                 err = self.do_logged_action(action, options)
             else:
-                self.log_action_header()
+                self.log_action_header(action, options)
                 err = self.do_action(action, options)
         else:
             err = self.do_action(action, options)
@@ -1305,7 +1305,7 @@ class BaseSvc(Crypt, ExtConfigMixin):
         actionlogfilehandler.setLevel(logging.INFO)
         self.logger.addHandler(actionlogfilehandler)
 
-        self.log_action_header()
+        self.log_action_header(action, options)
         err = self.do_action(action, options)
 
         # Push result and logs to database
@@ -1315,39 +1315,29 @@ class BaseSvc(Crypt, ExtConfigMixin):
         self.dblogger(action, begin, end, actionlogfile)
         return err
 
-    def log_action_obfuscate_secret(self, argv):
+    def log_action_obfuscate_secret(self, options):
+        data = {}
+        data.update(options)
+        for k in ("svcs", "parm_svcs", "namespace"):
+            try:
+                del data[k]
+            except KeyError:
+                pass
         if self.kind not in ("usr", "sec"):
-            return argv
-        try:
-            idx = argv.index("--value")
-        except ValueError:
-            return argv
-        try:
-            argv[idx+1]
-        except IndexError:
-            return argv
-        if argv[idx+1].startswith("-"):
-            return argv
-        argv[idx+1] = "xxx"
-        return argv
+            return data
+        for k, v in data.items():
+            if k == "value":
+                data["value"] = "xxx"
+        return data
 
-    def log_action_header(self):
-        argv = [] + sys.argv
-        try:
-            if argv[0].endswith("__main__.py"):
-                if len(argv) > 3 and argv[2] in ("-s", "--service"):
-                    _begin = 4
-                elif len(argv) > 2 and argv[1] == self.path:
-                    _begin = 2
-                else:
-                    _begin = 1
-                argv = self.log_action_obfuscate_secret(argv)
-                cmd = " ".join(argv[_begin:]).replace("%", "%%")
-                origin = os.environ.get("OSVC_ACTION_ORIGIN", "user")
-                runlog = "do %s (%s origin)" % (cmd, origin)
-                self.log.info(runlog, {"f_stream": False})
-        except IndexError:
-            pass
+    def log_action_header(self, action, options):
+        from utilities.render.command import format_command
+        origin = os.environ.get("OSVC_ACTION_ORIGIN", "user")
+        data = self.log_action_obfuscate_secret(options)
+        cmd = format_command(self.kind, action, data)
+        buff = "do %s (%s origin)" % (" ".join(cmd), origin)
+        buff = buff.replace("%", "%%")
+        self.log.info(buff, {"f_stream": False})
 
     def prepare_options(self, action, options):
         """

--- a/opensvc/daemon/handlers/node/action/post.py
+++ b/opensvc/daemon/handlers/node/action/post.py
@@ -3,8 +3,8 @@ from copy import deepcopy
 from subprocess import Popen, PIPE
 
 import daemon.handler
-from daemon.handler_action_helper import get_action_args_from_parser
 from env import Env
+from utilities.render.command import format_command
 from utilities.string import bdecode
 
 
@@ -69,26 +69,26 @@ class Handler(daemon.handler.BaseHandler):
 
         if options.action.startswith("daemon_"):
             subsystem = "daemon"
+            parser = "daemon"
             action = options.action[7:]
-            from commands.daemon.parser import OPT
         elif options.action.startswith("net_"):
             subsystem = "net"
+            parser = "network"
             action = options.action[4:]
-            from commands.network.parser import OPT
         elif options.action.startswith("network_"):
             subsystem = "net"
+            parser = "network"
             action = options.action[8:]
-            from commands.network.parser import OPT
         elif options.action.startswith("pool_"):
             subsystem = "pool"
+            parser = "pool"
             action = options.action[5:]
-            from commands.pool.parser import OPT
         else:
             subsystem = "node"
+            parser = "node"
             action = options.action
-            from commands.node.parser import OPT
 
-        cmd = get_action_args_from_parser(OPT, action, options)
+        cmd = format_command(parser, action, options.options or {})
         fullcmd = Env.om + [subsystem] + cmd
 
         thr.log_request("run 'om %s %s'" % (subsystem, " ".join(cmd)), nodename, **kwargs)

--- a/opensvc/daemon/handlers/object/action/post.py
+++ b/opensvc/daemon/handlers/object/action/post.py
@@ -7,9 +7,9 @@ import daemon.handler
 import daemon.rbac
 import daemon.shared as shared
 import core.exceptions as ex
-from daemon.handler_action_helper import get_action_args_from_parser
-from utilities.naming import split_path
 from env import Env
+from utilities.naming import split_path
+from utilities.render.command import format_command
 from utilities.string import bdecode
 
 GUEST_ACTIONS = (
@@ -187,8 +187,7 @@ class Handler(daemon.handler.BaseHandler, daemon.rbac.ObjectCreateMixin):
         if options.cmd:
             cmd = [options.cmd]
         else:
-            pmod = importlib.import_module("commands.{kind}.parser".format(kind=kind))
-            cmd = get_action_args_from_parser(pmod.OPT, options.action, options)
+            cmd = format_command(kind, options.action, options.options or {})
 
         fullcmd = Env.om + ["svc", "-s", options.path] + cmd
         thr.log_request("run 'om %s %s'" % (options.path, " ".join(cmd)), nodename, **kwargs)

--- a/opensvc/utilities/render/command.py
+++ b/opensvc/utilities/render/command.py
@@ -1,7 +1,7 @@
-def get_action_args_from_parser(parser, action, options):
+def format_command(kind, action, options):
     """
-    Return cmd for action handlers
-    :param parser:
+    Return a list-formatted CRM command from action and options.
+    :param subsystem:
     :param action:
     :param options:
     :return: cmd array
@@ -13,8 +13,11 @@ def get_action_args_from_parser(parser, action, options):
             if o.dest == "parm_" + searched_opt:
                 return o
 
+    import importlib
+    mod = importlib.import_module("commands.{kind}.parser".format(kind=kind))
+    parser = mod.OPT
     cmd = [action]
-    for opt, val in options.options.items():
+    for opt, val in options.items():
         po = find_opt(parser, opt)
         if po is None:
             continue
@@ -30,7 +33,7 @@ def get_action_args_from_parser(parser, action, options):
         elif po.action == "store_false" and not val:
             cmd.append(opt)
         elif po.type == "string":
-            opt += "=" + val
+            opt += "=" + str(val)
             cmd.append(opt)
         elif po.type == "integer":
             opt += "=" + str(val)


### PR DESCRIPTION
Some codepath, notably volume creation, submit object actions programmatically
(ex. volume.action("stop", ...)) instead of via a executed CRM
command, causing the secondary object to log the sys.argv of the original
command (ex. om <svc> provision).

This patch uses the POST /object/action and POST /node/action handlers
code to format the command to log from (parser, action, options) inputs.

This code now being used by the daemon and the CRM, host it in the
utilities.render.command module.