### PR TITLE
[test] Fix drbd test since --discard-my-data not always used

### DIFF
--- a/opensvc/tests/resource/disk/drbd/test_drbd.py
+++ b/opensvc/tests/resource/disk/drbd/test_drbd.py
@@ -235,7 +235,7 @@ class TestDrbdProvisioner:
                             'drbdadm_down',
                             'drbdadm_up',
                             'drbdadm_disconnect',
-                            'drbdadm_connect_discard']
+                            'drbdadm_connect']
         for method in expected_methods:
             mocker.patch.object(DiskDrbd, method, mocker.Mock(method))
         disk.provisioner()


### PR DESCRIPTION
drbdadm_connect_discard() has been renamed to drbdadm_connect