### PR TITLE
Fix a unprov orchestration loop situation

### DIFF
--- a/opensvc/core/resource.py
+++ b/opensvc/core/resource.py
@@ -1301,6 +1301,9 @@ class Resource(object):
     def is_provisioned(self, refresh=False):
         if not hasattr(self, "provisioner") and not hasattr(self, "provisioner_shared_non_leader"):
             return True
+        if "noaction" in self.tags:
+            # can not determine state if we can't run an action to toggle it
+            return
         if not refresh:
             flag = self.is_provisioned_flag()
             if flag is not None:


### PR DESCRIPTION
When a service has a ip resource with tags=noaction, the unprovisioner cannot
run, so the provisioned state of the resource will stay "true" and cause an
unprovision action loop.

This patch return a "None" resource provisioned state (not applicable) for
resource tagged "noaction".

Beware, at least one resource must have a valid provisioned state (a fs.flag
if nothing else).