### PR TITLE
Don't clear the "start failed" state while an orchestration is in pro…

### DIFF
--- a/opensvc/daemon/monitor.py
+++ b/opensvc/daemon/monitor.py
@@ -2180,10 +2180,11 @@ class Monitor(shared.OsvcThread, MonitorObjectOrchestratorManualMixin):
         smon = self.get_service_monitor(path)
         if not smon:
             return
-        if smon.global_expect is not None:
-            return
         if smon.status not in ("start failed", "place failed"):
             return
+        for nodename, instance in self.get_service_instances(path).items():
+            if instance["monitor"].get("global_expect") is not None:
+                return True
         self.log.info("clear %s %s: the service is up", path, smon.status)
         self.set_smon(path, status="idle")
 


### PR DESCRIPTION
…gress

We checked only that the local instance's global_expect value was None to
allow clearing a "start failed" state, which caused a ping pong on 'toc'
action for services configured with monitor_action=switch.

This orchestration relies on the "start failed" to remain until the "placed"
global expect is cleared, because if cleared the optimal instance can become
the cleared one, causing a failback.