### PR TITLE
Fix a "image not pulled yet" warning false positive in container.docker

### DIFF
--- a/opensvc/utilities/subsystems/docker.py
+++ b/opensvc/utilities/subsystems/docker.py
@@ -254,6 +254,10 @@ class ContainerLib(object):
                 return data
             if data["name"] == "docker.io/"+image_name:
                 return data
+            if data["name"].replace("docker.io/library/", "docker.io/") == image_name:
+                return data
+            if data["name"].replace("docker.io/", "docker.io/library/") == image_name:
+                return data
 
     def login_as_service_args(self):
         uuid = self.svc.node.conf_get("node", "uuid")


### PR DESCRIPTION
With image=docker.io/library/redis:6 docker images reports docker.io/redis
as the image name, which tricks the get_image() algorithm into thinking
it is not pulled.