### PR TITLE
Fix the "om <multi-object-selector> <orchestrated action> --wait" beh…

### DIFF
--- a/opensvc/core/node/node.py
+++ b/opensvc/core/node/node.py
@@ -2469,10 +2469,10 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
                 except AttributeError:
                     continue
                 try:
-                    svc.wait_daemon_mon_action(global_expect, wait=True, timeout=timeout, begin=begin)
+                    _timeout = timeout - (time.time() - begin)
+                    svc.wait_daemon_mon_action(global_expect, wait=True, timeout=_timeout, begin=begin)
                 except Exception as exc:
                     err += 1
-                timeout = timeout - (time.time() - begin)
 
         if need_aggregate:
             if self.options.single_service:


### PR DESCRIPTION
…aviour

The timeout was not honored correctly, causing a "timeout" error before the
expected time.