### PR TITLE
During daemon join, node.env may be removed from node.conf (fix)

### DIFF
--- a/opensvc/core/node/node.py
+++ b/opensvc/core/node/node.py
@@ -4476,7 +4476,7 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
         peer_env = ndata.get("node", {}).get("env")
         if peer_env and peer_env != self.env:
             toadd.append("node.env="+peer_env)
-        else:
+        elif peer_env is None:
             toremove.append("node.env")
         cluster_key = ndata.get("cluster", {}).get("secret")
         if cluster_key:


### PR DESCRIPTION
During 'om daemon join ...', local definition of node.env is removed from node.conf
when remote node.conf 'node.env' value is same value has local value.

This patch fix this, now:
   when remote 'node.env' value is not defined in node.conf
   then local keyword 'node.env' is removed from local node.conf (when present)