### PR TITLE
Fix provision failure (when volume#xx.exposed_devs refer a pending vo…

### DIFF
--- a/opensvc/drivers/resource/volume/__init__.py
+++ b/opensvc/drivers/resource/volume/__init__.py
@@ -375,7 +375,10 @@ class Volume(Resource):
 
     def exposed_devs(self):
         try:
-            return set([self.volsvc.device()])
+            dev = self.volsvc.device()
+            if dev is None:
+                return set()
+            return set([dev])
         except ex.Error:
             return set()
 


### PR DESCRIPTION
…lume#xx)

This regression start from #0ac4872dd

Error example:
  with volume#1 not yet provisioned
  and disk#1.vdev = {volume#1.exposed_devs[0]}

  om svc --kw disk#1.vdev --eval
    ['None']
  instead of []