### PR TITLE
Allow scoping on DEFAULT.create_pg

### DIFF
--- a/opensvc/core/objects/svcdict.py
+++ b/opensvc/core/objects/svcdict.py
@@ -55,6 +55,7 @@ PG_KEYWORDS = [
         "section": "DEFAULT",
         "keyword": "create_pg",
         "default": True,
+        "at": True,
         "convert": "boolean",
         "candidates": (True, False),
         "text": "Use process containers when possible. Containers allow capping memory, swap and cpu usage per service. Lxc containers are naturally containerized, so skip containerization of their startapp."


### PR DESCRIPTION
Unprivileged lxc containers don't have rw access to /sys.
In this case, users may need to set DEFAULT.create_pg@encapnodes=false.