### PR TITLE
Fix stop error on service fs resource when zone is not present

### DIFF
--- a/opensvc/drivers/resource/fs/__init__.py
+++ b/opensvc/drivers/resource/fs/__init__.py
@@ -294,8 +294,13 @@ class BaseFs(Resource):
             label = self.svc._get(self.rid+".dev", evaluate=False)
         else:
             label = self.device
-        if self.mount_point is not None:
-            label += "@" + self.mount_point
+        try:
+            mount_point = self.mount_point
+        except:
+            # accept undef mount point (for example when zone is down)
+            mount_point = "undef"
+        if mount_point is not None:
+            label += "@" + mount_point
         if self.fs_type not in ("tmpfs", "shm", "shmfs", "none", None):
             label = self.fs_type + " " + label
         return label


### PR DESCRIPTION
When zone doesn't exist, get fs label may fail
=> exception raise during pre stop status compute

Associated stack:

  File "/usr/share/opensvc/opensvc/core/resourceset.py", line 155, in status
    status = resource.status(**kwargs)
  File "/usr/share/opensvc/opensvc/core/resource.py", line 557, in status
    self.write_status()
  File "/usr/share/opensvc/opensvc/core/resource.py", line 569, in write_status
    self.write_status_last()
  File "/usr/share/opensvc/opensvc/core/resource.py", line 665, in write_status_last
    "label": self.label,
  File "/usr/share/opensvc/opensvc/utilities/lazy.py", line 32, in _lazyprop
    setattr(self, attr_name, fn(self))
  File "/usr/share/opensvc/opensvc/drivers/resource/fs/__init__.py", line 297, in label
    if self.mount_point is not None:
  File "/usr/share/opensvc/opensvc/utilities/lazy.py", line 32, in _lazyprop
    setattr(self, attr_name, fn(self))
  File "/usr/share/opensvc/opensvc/drivers/resource/fs/__init__.py", line 255, in mount_point
    raise ex.Error("zone %s, referenced in %s, not found" % (self.zone, self.rid))
<class 'core.exceptions.Error'> zone zone10-1, referenced in fs#0, not found None
@ n:sol114-1 o:flexsvc-zone10 r:container#0 sc:n
  zone zone10-1 does not exist
zone zone10-1, referenced in fs#0, not found