### PR TITLE
Remove warning message during cluster delete --rid...

### DIFF
--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -62,6 +62,8 @@ ACTION_NO_ASYNC = [
     "print_status",
 ]
 
+KIND_ACTION_NO_ASYNC = ["ccfg"]
+
 ACTION_ANY_NODE = (
     "decode",
     "delete",
@@ -1428,7 +1430,7 @@ class BaseSvc(Crypt, ExtConfigMixin):
         return False
 
     def async_action(self, action, wait=None, timeout=None):
-        if action in ACTION_NO_ASYNC:
+        if action in ACTION_NO_ASYNC or self.kind in KIND_ACTION_NO_ASYNC:
             return
         if self.is_remote_action(action):
             options = self.prepare_async_options()

--- a/opensvc/tests/commands/cluster/test_cluster_commands.py
+++ b/opensvc/tests/commands/cluster/test_cluster_commands.py
@@ -1,0 +1,41 @@
+import pytest
+
+import commands.svc
+from core.objects.ccfg import Ccfg
+from env import Env
+
+
+@pytest.mark.ci
+@pytest.mark.usefixtures('has_euid_0', 'osvc_path_tests')
+class TestClusterCommand:
+    @staticmethod
+    def test_print_config(mock_argv):
+        mock_argv(["om", "-s", "cluster", "print", "config"])
+        assert commands.svc.Mgr()() == 0
+
+    @staticmethod
+    def test_a_default_cluster_config_settings_are_created(mock_argv):
+        # ensure cluster config is created
+        mock_argv(["om", "-s", "cluster", "print", "config"])
+        assert commands.svc.Mgr()() == 0
+        cluster = Ccfg()
+        assert cluster.cluster_name == "default"
+        assert cluster.nodes == {Env.nodename}
+        assert len(cluster.cd["cluster"]["secret"]) > 0
+
+    @staticmethod
+    def test_can_add_unicast_hb(mock_argv):
+        mock_argv(["om", "-s", "cluster", "set", "--kw", "hb#1.type=unicast"])
+        assert commands.svc.Mgr()() == 0
+        cluster = Ccfg()
+        assert "hb#1" in cluster.conf_sections()
+        assert cluster.cd["hb#1"]["type"] == "unicast"
+
+    @staticmethod
+    def test_can_delete_an_hb_section(mock_argv):
+        mock_argv(["om", "-s", "cluster", "set", "--kw", "hb#1.type=unicast"])
+        assert commands.svc.Mgr()() == 0
+        mock_argv(["om", "-s", "cluster", "delete", "--rid", "hb#1"])
+        assert commands.svc.Mgr()() == 0
+        cluster = Ccfg()
+        assert "hb#1" not in cluster.conf_sections()


### PR DESCRIPTION
This patch remove warning: "ignore delete request: not supported on ccfg objects"
during "om cluster delete --rid ..."

Cluster config action are always sync, so this message was unnecessary.