### PR TITLE
Add boot method for linux lv

### DIFF
--- a/opensvc/drivers/resource/disk/lv/linux.py
+++ b/opensvc/drivers/resource/disk/lv/linux.py
@@ -166,3 +166,5 @@ class DiskLv(BaseDiskLv):
 
         self.svc.node.unset_lazy("devtree")
 
+    def boot(self):
+        self.do_stop()


### PR DESCRIPTION
* lv resource taken from a local mutualized vg are auto-activated at boot time
* this is evaluated as 'up' status and can lead to an aggregated warn status at the service level
* the boot method deactivate lv resources at daemon start