### PR TITLE
features: ['daemon mutex', 'stop listener client'], fixes:['daemon leave => hb msg full']

### DIFF
--- a/opensvc/commands/daemon/parser.py
+++ b/opensvc/commands/daemon/parser.py
@@ -24,10 +24,14 @@ OPT = Storage({
         action="store", dest="secret",
         help="The cluster secret used as the AES key in the cluster "
              "communications."),
+    "session_id": Option(
+        "--session-id", default=None, action="store", dest="session_id",
+        help="Specify an alive daemon listener client session id, as listed:cmd:`om daemon "
+             "status` output."),
     "thr_id": Option(
         "--thread-id", default=None, action="store", dest="thr_id",
         help="Specify a daemon thread, as listed in the :cmd:`om daemon "
-             "status` output."),
+             "status --format <json|flat_json>` output."),
     "timeout": Option(
         "--timeout",
         action="store", dest="time",
@@ -81,9 +85,12 @@ ACTIONS = {
             ],
         },
         "stop": {
-            "msg": "Stop the daemon or a daemon thread pointed by :opt:`--thread-id`.",
+            "msg": ("Stop the daemon or a daemon thread pointed by :opt:`--thread-id`."
+                    " listener clients can be marked for stop with session id `xxx` can be marked for stop using"
+                    " `--thread-id session-id-xxx`."),
             "options": [
                 OPT.thr_id,
+                OPT.session_id,
             ],
         },
         "join": {

--- a/opensvc/commands/daemon/parser.py
+++ b/opensvc/commands/daemon/parser.py
@@ -103,6 +103,9 @@ ACTIONS = {
         "dns_dump": {
             "msg": "Dump the content of the cluster zone.",
         },
+        "mutex_status": {
+            "msg": "Show daemon mutex status.",
+        },
     },
 }
 

--- a/opensvc/core/comm.py
+++ b/opensvc/core/comm.py
@@ -532,6 +532,7 @@ class Crypt(object):
                 buff = sock.recv(bufsize)
             except SSLError as exc:
                 if exc.errno == ssl.SSL_ERROR_WANT_READ:
+                    time.sleep(PAUSE)
                     continue
                 raise
             break

--- a/opensvc/daemon/handlers/daemon/mutex/get.py
+++ b/opensvc/daemon/handlers/daemon/mutex/get.py
@@ -1,0 +1,19 @@
+import daemon.handler
+from daemon.shared import daemon_mutex_status
+
+
+class Handler(daemon.handler.BaseHandler):
+    """
+    Return daemon mutex status
+    """
+    routes = (
+        ("GET", "daemon_mutex"),
+        (None, "daemon_mutex"),
+    )
+    prototype = []
+
+    def action(self, nodename, thr=None, **kwargs):
+        return {
+            "data": {"mutexes": daemon_mutex_status(thr.log)},
+            "status": 0,
+        }

--- a/opensvc/daemon/listener.py
+++ b/opensvc/daemon/listener.py
@@ -850,6 +850,8 @@ class ClientHandler(shared.OsvcThread):
             self.usr_auth = None
             self.usr_grants = {}
         self.events_counter = 0
+        self.sid = str(uuid.uuid4())
+
 
     def __str__(self):
         try:
@@ -867,7 +869,6 @@ class ClientHandler(shared.OsvcThread):
     def run(self):
         try:
             close = True
-            self.sid = str(uuid.uuid4())
             self.parent.stats.sessions.alive[self.sid] = Storage({
                 "created": time.time(),
                 "addr": self.addr[0],

--- a/opensvc/daemon/listener.py
+++ b/opensvc/daemon/listener.py
@@ -873,6 +873,7 @@ class ClientHandler(shared.OsvcThread):
                 "addr": self.addr[0],
                 "encrypted": self.encrypted,
                 "progress": "init",
+                "ident": self.ident,
             })
             if self.scheme == "h2":
                 self.handle_h2_client()

--- a/opensvc/daemon/listener.py
+++ b/opensvc/daemon/listener.py
@@ -65,6 +65,7 @@ if six.PY2:
 
 RE_LOG_LINE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-2][0-9]:[0-6][0-9]:[0-6][0-9],[0-9]{3} .* \| ")
 JANITORS_INTERVAL = 0.5
+LSNR_CLIENT_DELAY_AFTER_RESET = 0.1
 ICON = base64.b64decode("iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAABigAAAYoBM5cwWAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAJKSURBVDiNbZJLSNRRFMZ/5/5HbUidRSVSuGhMzUKiB9SihYaJQlRSm3ZBuxY9JDRb1NSi7KGGELRtIfTcJBjlItsohT0hjcpQSsM0CMfXzP9xWszM35mpA/dy7+Wc7/vOd67wn9gcuZ8bisa3xG271LXthTdNL/rZ0B0VQbNzA+mX2ra+kL04d86NxY86QpEI8catv0+SIyOMNnr6aa4ba/aylL2cTdVI6tBwrbfUXvKeOXY87Ng2jm3H91dNnWrd++U89kIx7jw48+DMf0bcOtk0MA5gABq6egs91+pRCKc01lXOnG2tn4yAKUYkmWpATDlqevRjdb4PYMWDrSiVqIKCosMX932vAYoQQ8bCgGoVajcDmIau3jxP9bj6/igoFqiTuCeLkDQQQOSEDm3PMQEnfxeqhYlSH6Si6WF4EJjIZE+1AqiGCAZ3GoT1yYcEuSqqMDBacOXMo5JORDJBRJa9V0qMqkiGfHwt1vORlW3ND9ZdB/mZNDANJNmgUXcsnTmx+WCBvuH8G6/GC276BpLmA95XMxvVQdC5NOYkkC8ocG9odRCRzEkI0yzF3pn+SM2SKrfJiCRQYp9uqf9l/p2E3pIdr20DkCvBS6o64tMvtzLTfmTiQlGh05w1iSFyQ23+R3rcsjsqrlPr4X3Q5f6nOw7/iOwpX+wEsyLNwLcIB6TsSQzASon+1n83unbboTtiaczz3FVXD451VG+cawfyEAHPGcdzruPOHpOKp39SdcvzyAqdOh3GsyoBsLxJ1hS+F4l42Xl/Abn0Ctwc5dldAAAAAElFTkSuQmCC")
 
 ROUTED_ACTIONS = {
@@ -913,6 +914,7 @@ class ClientHandler(shared.OsvcThread):
             close = False
         except (OSError, socket.error) as exc:
             if exc.errno in (0, ECONNRESET):
+                time.sleep(LSNR_CLIENT_DELAY_AFTER_RESET)
                 pass
         except RuntimeError as exc:
             self.log.error("%s", exc)

--- a/opensvc/daemon/main.py
+++ b/opensvc/daemon/main.py
@@ -163,10 +163,8 @@ class Daemon(object):
                 "services": {},
             }
         }
-        try:
-            initial_data["daemon"] = {"ident": threading.get_ident()}
-        except:
-            pass
+        if hasattr(threading, "get_ident"):
+            initial_data["daemon"] = {"ident": threading.get_ident()}  # pylint: disable=no-member
         shared.DAEMON_STATUS.set([], initial_data)
 
     @lazy

--- a/opensvc/daemon/main.py
+++ b/opensvc/daemon/main.py
@@ -163,6 +163,10 @@ class Daemon(object):
                 "services": {},
             }
         }
+        try:
+            initial_data["daemon"] = {"ident": threading.get_ident()}
+        except:
+            pass
         shared.DAEMON_STATUS.set([], initial_data)
 
     @lazy

--- a/opensvc/daemon/monitor.py
+++ b/opensvc/daemon/monitor.py
@@ -3603,7 +3603,7 @@ class Monitor(shared.OsvcThread, MonitorObjectOrchestratorManualMixin):
         left = set(self.list_nodes()) - set(self.cluster_nodes)
         for node in left:
             self.log.info("purge left node %s data", node)
-            self.thread_data.unset_safe(["nodes", node])
+            self.delete_peer_data(node)
 
     def update_node_data(self):
         """
@@ -4178,6 +4178,11 @@ class Monitor(shared.OsvcThread, MonitorObjectOrchestratorManualMixin):
         change = False
         # self.log.debug("received %s from node %s: current gen %d, our gen local:%s peer:%s",
         #                kind, nodename, current_gen, shared.LOCAL_GEN.get(nodename), our_gen_on_peer) # COMMENT
+
+        if nodename not in self.cluster_nodes + self.cluster_drpnodes:
+            self.log.info("drop %s message from non member node %s", kind, nodename)
+            return change
+
         if kind == "patch":
             if not self.nodes_data.exists([nodename]):
                 # happens during init, or after join. ignore the patch, and ask for a full

--- a/opensvc/daemon/shared.py
+++ b/opensvc/daemon/shared.py
@@ -124,6 +124,11 @@ LOCKS_LOCK = RLock()
 RX = queue.Queue()
 RX_LOCK = RLock()
 
+# DEFERRED_STOP_LISTENER_CLIENTS define set of listener client session-id marked to be stopped
+DEFERRED_STOP_LISTENER_CLIENTS = set()
+# DEFERRED_STOP_LISTENER_CLIENTS_LOCK serialize access to DEFERRED_STOP_LISTENER_CLIENTS
+DEFERRED_STOP_LISTENER_CLIENTS_LOCK = threading.RLock()
+
 # thread loop conditions and helpers
 DAEMON_STOP = threading.Event()
 MON_TICKER = threading.Condition()
@@ -162,6 +167,7 @@ try:
     HB_MSG_LOCK.name = "HB_MSG"
     RUN_DONE_LOCK.name = "RUN_DONE"
     LOCKS_LOCK.name = "LOCKS"
+    DEFERRED_STOP_LISTENER_CLIENTS_LOCK.name = "DEFERRED_STOP_LISTENER_CLIENTS"
 except AttributeError:
     pass
 
@@ -176,6 +182,7 @@ def daemon_mutex_status(log=None):
         "CONFIG": str(CONFIG_LOCK),
         "RUN_DONE": str(RUN_DONE_LOCK),
         "LOCKS": str(LOCKS_LOCK),
+        "DEFERRED_STOP_LISTENER_CLIENTS": str(DEFERRED_STOP_LISTENER_CLIENTS_LOCK),
     }
 
     if log:

--- a/opensvc/daemon/shared.py
+++ b/opensvc/daemon/shared.py
@@ -188,16 +188,17 @@ def daemon_mutex_status(log=None):
     if log:
         # TODO find better way to get log hnadlers locks
         # logging.PlaceHolder is not in logging public api
-        logger_keys = list(log.manager.loggerDict)
+        loggerDict = log.logger.manager.loggerDict
+        logger_keys = list(loggerDict)
         for k in logger_keys:
             try:
-                logger_item = log.manager.loggerDict[k]
+                logger_item = loggerDict[k]
                 if not isinstance(logger_item, logging.PlaceHolder):
                     i = 0
                     for h in logger_item.handlers:
                         i += 1
                         if h.lock:
-                            data["logger[%s]-handler[%s]" % (logger_item.name, repr(h))] = str(h.lock)
+                            data["logger[%s]-%d-handler[%s]" % (logger_item.name, i, repr(h))] = str(h.lock)
             except:
                 # best effort to retrieve logger handlers locks
                 pass

--- a/opensvc/daemon/shared.py
+++ b/opensvc/daemon/shared.py
@@ -343,6 +343,8 @@ class OsvcThread(threading.Thread, Crypt):
             data["alerts"] = self.alerts
         if self.tid:
             data["tid"] = self.tid
+        if hasattr(self, "ident"):
+            data["ident"] = self.ident
         return data
 
     def exit(self, exit_status=0):

--- a/opensvc/tests/commands/daemon/test_daemon.py
+++ b/opensvc/tests/commands/daemon/test_daemon.py
@@ -257,9 +257,9 @@ class TestNodemgrDaemonActions:
         mutex_free = 0
         for name, value in status.items():
             if "owner=None" in value or "unlocked" in value:
-                mutex_free =+ 1
+                mutex_free = mutex_free + 1
             else:
-                mutex_busy =+ 1
+                mutex_busy = mutex_busy + 1
         assert mutex_free > mutex_busy, \
             "found more busy than free mutexes: \n%s" % status
         assert len([k for k in status.keys() if "logger" in k]) > 0, "no logger in mutexes"

--- a/opensvc/tests/commands/daemon/test_daemon.py
+++ b/opensvc/tests/commands/daemon/test_daemon.py
@@ -246,6 +246,17 @@ class TestNodemgrDaemonActions:
         assert status['listener']['state'] == 'running'
         assert status['scheduler']['state'] == 'running'
 
+        print('daemon mutex status json...')
+        with capture_stdout(tmp_file):
+            assert commands.daemon.main(argv=["mutex", "status", "--format", "json"]) == 0
+        with open(tmp_file, 'r') as status_file:
+            status = json.load(status_file)
+        print(status)
+        assert len(status) > 0, "no mutexes returned"
+        for name, value in status.get_items():
+            assert "unlocked" in value, "'%s' mutex is not unlocked, value: '%s'" % (name, value)
+        assert len([k for k in status.keys() if "logger" in k]) > 0, "no logger in mutexes"
+
         print('daemon status...')
         assert commands.daemon.main(argv=["status", "--debug"]) == 0
 

--- a/opensvc/tests/commands/daemon/test_daemon.py
+++ b/opensvc/tests/commands/daemon/test_daemon.py
@@ -253,8 +253,15 @@ class TestNodemgrDaemonActions:
             status = json.load(status_file)
         print(status)
         assert len(status) > 0, "no mutexes returned"
-        for name, value in status.get_items():
-            assert "unlocked" in value, "'%s' mutex is not unlocked, value: '%s'" % (name, value)
+        mutex_busy = 0
+        mutex_free = 0
+        for name, value in status.items():
+            if "owner=None" in value or "unlocked" in value:
+                mutex_free =+ 1
+            else:
+                mutex_busy =+ 1
+        assert mutex_free > mutex_busy, \
+            "found more busy than free mutexes: \n%s" % status
         assert len([k for k in status.keys() if "logger" in k]) > 0, "no logger in mutexes"
 
         print('daemon status...')

--- a/opensvc/tests/commands/svc/test_svc_start_app.py
+++ b/opensvc/tests/commands/svc/test_svc_start_app.py
@@ -15,14 +15,14 @@ class TestStartApp:
         create_args = [
             "-s", svcname,
             "create",
-            "--kw", "start_timeout=1",
+            "--kw", "start_timeout=2",
             "--kw", "app#1.start=%s" % env.Env.syspaths.true,
         ]
         assert Mgr()(argv=create_args) == 0
         begin = time.time()
         exit_code = Mgr()(argv=["-s", svcname, "start", "--local"])
 
-        assert time.time() - begin < 0.5, \
+        assert time.time() - begin < 1.5, \
             "wait for resource status up should return earlier when no checker"
 
         assert exit_code == 0, (


### PR DESCRIPTION
This pr add followings:

features:
  - show daemon mutex: 'om daemon mutex status'
  - stop listener client thread: 'om daemon stop --thread-id'

Fixed bug:
  - hb may stay in full message mode after 'om daemon leave' 
  
    purge left node helper

    ```2021-08-04 06:53:43,479 INFO n:u2004-local-1 c:listener/::ffff:172.20.16.18 | node u2004-local-8 is leaving
    2021-08-04 06:53:43,486 INFO n:u2004-local-1 c:listener/::ffff:172.20.16.18 | set cluster.nodes=u2004-local-2 u2004-local-3 u2004-local-4 u2004-local-5 u2004-local-6 u2004-local-7 u2004-local-9 u2004-local-10 u2004-local-11 u2004-local-12 u2004-local-13 u2004-local-14 u2004-local-15 u2004-local-16 u2004-local-1 in cluster config
    2021-08-04 06:53:43,487 INFO n:u2004-local-1 c:listener/::ffff:172.20.16.18 | unset cluster.nodes in node config
    2021-08-04 06:53:43,488 INFO n:u2004-local-1 c:listener/::ffff:172.20.16.18 | delete node u2004-local-8 from nodes data

    -> Monitor merge pending message is applied before daemon config reloaded => will switch to full
    2021-08-04 06:53:43,526 INFO n:u2004-local-1 c:monitor | u2004-local-8 was not yet in nodes data view, ask for a full
    2021-08-04 06:53:44,042 INFO n:u2004-local-1 c:monitor | install node u2004-local-14 full dataset gen 17, peer has gen 179 of our dataset

    2021-08-04 06:53:44,044 INFO n:u2004-local-1 c:monitor | /var/lib/opensvc/nodes_info.json updated
    2021-08-04 06:53:44,695 INFO sid:96d89e0e-bae5-4d0d-be16-185d8b223440 n:u2004-local-1 | ip link set dev obr_backend1 up
    2021-08-04 06:53:44,803 INFO sid:96d89e0e-bae5-4d0d-be16-185d8b223440 n:u2004-local-1 | ip route replace 10.11.0.0/22 via 172.20.16.12 table main
    ...
    2021-08-04 06:53:45,539 INFO sid:96d89e0e-bae5-4d0d-be16-185d8b223440 n:u2004-local-1 | ip route replace 10.11.0.0/22 dev obr_backend1 table main

    -> hb detect need switch to full message mode
    2021-08-04 06:53:46,901 INFO n:u2004-local-1 c:hb#1.tx | change message type to full (gen 179)
    2021-08-04 06:53:48,818 WARNING n:u2004-local-1 c:hb#1.tx | send to u2004-local-8 (u2004-local-8:10000) error: [Errno 111] Connection refused
    2021-08-04 06:53:49,278 INFO n:u2004-local-1 c:main | node config reloaded (changed)
    2021-08-04 06:53:49,291 INFO n:u2004-local-1 c:listener | node config change
    2021-08-04 06:53:49,292 INFO n:u2004-local-1 c:listener | cluster vip 172.20.16.160/24@eth2
    2021-08-04 06:53:49,300 INFO n:u2004-local-1 c:listener | tls listener [::]:1215 config unchanged
    2021-08-04 06:53:49,314 INFO n:u2004-local-1 c:listener | aes listener [::]:1214 config unchanged
    2021-08-04 06:53:49,319 INFO n:u2004-local-1 c:listener | raw listener /var/lib/opensvc/lsnr/lsnr.sock config unchanged
    2021-08-04 06:53:49,320 INFO n:u2004-local-1 c:listener | raw listener /var/lib/opensvc/lsnr/lsnr.sock config unchanged
    2021-08-04 06:53:49,689 INFO n:u2004-local-1 c:dns | node config change
    2021-08-04 06:53:49,725 INFO n:u2004-local-1 c:hb#1.rx | node config change
    2021-08-04 06:53:49,726 INFO n:u2004-local-1 c:hb#1.rx | hb nodes: ['u2004-local-2', 'u2004-local-3', 'u2004-local-4', 'u2004-local-5', 'u2004-local-6', 'u2004-local-7', 'u2004-local-9', 'u2004-local-10', 'u2004-local-11', 'u2004-local-12', 'u2004-local-13', 'u2004-local-14', 'u2004-local-15', 'u2004-local-16', 'u2004-local-1']
    2021-08-04 06:53:49,746 INFO n:u2004-local-1 c:hb#1.rx | listening on [::]:10000
    2021-08-04 06:53:52,471 INFO n:u2004-local-1 c:monitor | install node u2004-local-2 full dataset gen 18, peer has gen 179 of our dataset
    ...
    2021-08-04 06:53:52,787 INFO n:u2004-local-1 c:monitor | install node u2004-local-15 full dataset gen 20, peer has gen 179 of our dataset
    2021-08-04 06:53:52,851 INFO n:u2004-local-1 c:monitor | node config change
    2021-08-04 06:53:52,862 INFO n:u2004-local-1 c:monitor | /var/lib/opensvc/nodes_info.json updated
    2021-08-04 06:53:54,248 INFO n:u2004-local-1 c:hb#1.tx | node config change
    2021-08-04 06:53:54,254 INFO n:u2004-local-1 c:hb#1.tx | hb nodes: ['u2004-local-2', 'u2004-local-3', 'u2004-local-4', 'u2004-local-5', 'u2004-local-6', 'u2004-local-7', 'u2004-local-9', 'u2004-local-10', 'u2004-local-11', 'u2004-local-12', 'u2004-local-13', 'u2004-local-14', 'u2004-local-15', 'u2004-local-16', 'u2004-local-1']
    2021-08-04 06:54:07,005 INFO n:u2004-local-1 c:monitor | service cluster configuration change
    -> detected left nodes (u2004-local-8)
    2021-08-04 06:54:07,031 INFO n:u2004-local-1 c:monitor | purge left node u2004-local-8 data
    -> now also remove GEN related settings from left node => no need for full
    2021-08-04 06:54:07,032 INFO n:u2004-local-1 c:monitor | delete node u2004-local-8 from nodes data
    2021-08-04 06:54:07,621 INFO n:u2004-local-1 c:hb#1.tx | change message type to patch (gen 180)
    ```
    
    bug example:
    ```
    Jul 29 15:09:24 n2.local python3[14571]: n:n2.local c:listener/::ffff:192.168.0.4 delete node n4.local from nodes data
    Jul 29 15:09:24 n2.local python3[14571]: n:n2.local c:monitor n4.local was not yet in nodes data view, ask for a full
    Jul 29 15:09:25 n2.local python3[14571]: n:n2.local c:monitor waiting for node n4.local dataset
    Jul 29 15:09:25 n2.local python3[14571]: n:n2.local c:monitor purge left node n4.local data
    Jul 29 15:09:40 n2.local python3[14571]: n:n2.local c:hb#0.rx node n4.local hb status beating => stale    
    ```