### PR TITLE
potential high cpu usage on listener client tls (fix)

### DIFF
--- a/opensvc/daemon/handlers/events/get.py
+++ b/opensvc/daemon/handlers/events/get.py
@@ -85,7 +85,6 @@ class Handler(daemon.handler.BaseHandler):
         else:
             try:
                 thr.raw_push_action_events()
-            except BlockingIOError as exc:
-                thr.log.info("end client handler 'GET events' on BlockingIOError '%s'", exc)
-            except BrokenPipeError as exc:
-                thr.log.info("end client handler 'GET events' on BrokenPipeError '%s'", exc)
+            except OSError as exc:
+                # example: BlockingIOError, BrokenPipeError
+                thr.log.info("end client handler 'GET events' on '%s'", exc)

--- a/opensvc/daemon/handlers/events/get.py
+++ b/opensvc/daemon/handlers/events/get.py
@@ -83,6 +83,9 @@ class Handler(daemon.handler.BaseHandler):
                 "fn": "h2_push_action_events",
             })
         else:
-            thr.raw_push_action_events()
-
-
+            try:
+                thr.raw_push_action_events()
+            except BlockingIOError as exc:
+                thr.log.info("end client handler 'GET events' on BlockingIOError '%s'", exc)
+            except BrokenPipeError as exc:
+                thr.log.info("end client handler 'GET events' on BrokenPipeError '%s'", exc)

--- a/opensvc/daemon/listener.py
+++ b/opensvc/daemon/listener.py
@@ -1506,7 +1506,8 @@ class ClientHandler(shared.OsvcThread):
     def raw_send_result(self, result):
         if result is None:
             return
-        self.parent.stats.sessions.alive[self.sid].progress = "sending %s result" % self.parent.stats.sessions.alive[self.sid].progress
+        progress = "sending %s result" % self.parent.stats.sessions.alive[self.sid].progress
+        self.parent.stats.sessions.alive[self.sid].progress = progress
         self.conn.setblocking(True)
         if self.encrypted:
             message = self.encrypt(result)
@@ -1517,9 +1518,9 @@ class ClientHandler(shared.OsvcThread):
                 self.conn.sendall(chunk)
             except socket.error as exc:
                 if exc.errno == EPIPE:
-                    self.log.info(exc)
+                    self.log.info("sendall '%s' while '%s'", exc, progress)
                 else:
-                    self.log.warning(exc)
+                    self.log.warning("sendall '%s' while '%s'", exc, progress)
                 break
         message_len = len(message)
         self.parent.stats.sessions.tx += message_len

--- a/opensvc/daemon/listener.py
+++ b/opensvc/daemon/listener.py
@@ -1387,11 +1387,6 @@ class ClientHandler(shared.OsvcThread):
                 pass
             except socket.timeout:
                 pass
-            except socket.error as exc:
-                if exc.errno in (0, ECONNRESET):
-                    continue
-                self.log.error("%s", exc)
-                return
             except h2.exceptions.StreamClosedError:
                 return
             except ConnectionResetError:

--- a/opensvc/daemon/listener.py
+++ b/opensvc/daemon/listener.py
@@ -65,7 +65,6 @@ if six.PY2:
 
 RE_LOG_LINE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-2][0-9]:[0-6][0-9]:[0-6][0-9],[0-9]{3} .* \| ")
 JANITORS_INTERVAL = 0.5
-LSNR_CLIENT_DELAY_AFTER_RESET = 0.1
 ICON = base64.b64decode("iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAABigAAAYoBM5cwWAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAJKSURBVDiNbZJLSNRRFMZ/5/5HbUidRSVSuGhMzUKiB9SihYaJQlRSm3ZBuxY9JDRb1NSi7KGGELRtIfTcJBjlItsohT0hjcpQSsM0CMfXzP9xWszM35mpA/dy7+Wc7/vOd67wn9gcuZ8bisa3xG271LXthTdNL/rZ0B0VQbNzA+mX2ra+kL04d86NxY86QpEI8catv0+SIyOMNnr6aa4ba/aylL2cTdVI6tBwrbfUXvKeOXY87Ng2jm3H91dNnWrd++U89kIx7jw48+DMf0bcOtk0MA5gABq6egs91+pRCKc01lXOnG2tn4yAKUYkmWpATDlqevRjdb4PYMWDrSiVqIKCosMX932vAYoQQ8bCgGoVajcDmIau3jxP9bj6/igoFqiTuCeLkDQQQOSEDm3PMQEnfxeqhYlSH6Si6WF4EJjIZE+1AqiGCAZ3GoT1yYcEuSqqMDBacOXMo5JORDJBRJa9V0qMqkiGfHwt1vORlW3ND9ZdB/mZNDANJNmgUXcsnTmx+WCBvuH8G6/GC276BpLmA95XMxvVQdC5NOYkkC8ocG9odRCRzEkI0yzF3pn+SM2SKrfJiCRQYp9uqf9l/p2E3pIdr20DkCvBS6o64tMvtzLTfmTiQlGh05w1iSFyQ23+R3rcsjsqrlPr4X3Q5f6nOw7/iOwpX+wEsyLNwLcIB6TsSQzASon+1n83unbboTtiaczz3FVXD451VG+cawfyEAHPGcdzruPOHpOKp39SdcvzyAqdOh3GsyoBsLxJ1hS+F4l42Xl/Abn0Ctwc5dldAAAAAElFTkSuQmCC")
 
 ROUTED_ACTIONS = {
@@ -914,7 +913,6 @@ class ClientHandler(shared.OsvcThread):
             close = False
         except (OSError, socket.error) as exc:
             if exc.errno in (0, ECONNRESET):
-                time.sleep(LSNR_CLIENT_DELAY_AFTER_RESET)
                 pass
         except RuntimeError as exc:
             self.log.error("%s", exc)


### PR DESCRIPTION

  * listener client high cpu usage on invalid tls, or early closed connection (fix)
  * update log during some sendall errrors