### PR TITLE
Fix a stack in the "om mon --section nodes" codepath

### DIFF
--- a/opensvc/utilities/render/cluster/__init__.py
+++ b/opensvc/utilities/render/cluster/__init__.py
@@ -225,7 +225,13 @@ def list_print(data, right=None):
     outs = ""
     if len(data) == 0:
         return ""
-    widths = [0] * len(data[-1])
+    widths = 0
+    for line in data:
+        if len(line) != 0:
+            widths = [0] * len(line)
+            break
+    if widths == 0:
+        return ""
     _data = []
     for line in data:
         _data.append(tuple(map(lambda x: x.encode("utf-8") if x is not None else "".encode("utf-8"), line)))


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/opt/opensvc/opensvc/__main__.py", line 131, in <module>
    ret = main(sys.argv)
  File "/opt/opensvc/opensvc/__main__.py", line 123, in main
    ret = main(argv=argv[1:])
  File "/opt/opensvc/opensvc/commands/svcmon.py", line 301, in main
    _main(node, argv)
  File "/opt/opensvc/opensvc/commands/svcmon.py", line 154, in _main
    svcmon(node, options)
  File "/opt/opensvc/opensvc/commands/svcmon.py", line 280, in svcmon
    outs = format_cluster(paths=expanded_svcs, node=nodes,
  File "/opt/opensvc/opensvc/utilities/render/cluster/__init__.py", line 1071, in format_cluster
    return print_section(out)
  File "/opt/opensvc/opensvc/utilities/render/cluster/__init__.py", line 255, in print_section
    return list_print(data)
  File "/opt/opensvc/opensvc/utilities/render/cluster/__init__.py", line 236, in list_print
    if strlen > widths[i]:
IndexError: list index out of range