### PR TITLE
Fix a stack on disk.scsireserv stop when a mpath has no paths

### DIFF
--- a/opensvc/core/network.py
+++ b/opensvc/core/network.py
@@ -160,7 +160,8 @@ class NetworksMixin(object):
         nets = self.networks_data_from_cni_confs()
         sections = list(self.conf_sections("network"))
         if "network#default" not in sections:
-            sections.append("network#default")
+            if self.oget(section, "network") not in ("None", "none", None):
+                sections.append("network#default")
         for section in sections:
             _, name = section.split("#", 1)
             config = {}
@@ -171,6 +172,8 @@ class NetworksMixin(object):
                     config["subnets"] = self.oget_scopes(section, "subnet", rtype=config["type"])
                     config["gateway"] = self.oget_scopes(section, "gateway", rtype=config["type"])
             if not config:
+                continue
+            if config.get("network") in ("None", "none", None):
                 continue
             routes = self.routes(name, config)
             if config["type"] == "routed_bridge" and not any(config["subnets"][n] for n in config["subnets"]):

--- a/opensvc/core/network.py
+++ b/opensvc/core/network.py
@@ -160,8 +160,7 @@ class NetworksMixin(object):
         nets = self.networks_data_from_cni_confs()
         sections = list(self.conf_sections("network"))
         if "network#default" not in sections:
-            if self.oget(section, "network") not in ("None", "none", None):
-                sections.append("network#default")
+            sections.append("network#default")
         for section in sections:
             _, name = section.split("#", 1)
             config = {}

--- a/opensvc/drivers/resource/disk/scsireserv/sg.py
+++ b/opensvc/drivers/resource/disk/scsireserv/sg.py
@@ -122,7 +122,7 @@ class DiskScsireservSg(BaseDiskScsireserv):
     def use_mpathpersist(self, disk):
         if not self.has_capability("disk.scsireserv.mpathpersist"):
             return False
-        if [disk] != self.devs[disk]:
+        if [disk] != self.devs.get(disk, []):
             return True
         return False
 


### PR DESCRIPTION
In this situation, the use_mpathpersist() method stacks trying to
access self.devs[disk] when self.devs is empty.