### PR TITLE
Fix the drbd over vg usage algo

### DIFF
--- a/opensvc/drivers/pool/drbd.py
+++ b/opensvc/drivers/pool/drbd.py
@@ -143,8 +143,8 @@ class Pool(BasePool):
             if ret != 0:
                 return data
             l = out.splitlines()[-1].split()
-            data["free"] = int(l[1].split(".")[0])
-            data["size"] = int(l[0].split(".")[0])
+            data["free"] = int(l[1].split(".")[0].rstrip("k"))
+            data["size"] = int(l[0].split(".")[0].rstrip("k"))
             data["used"] = data["size"] - data["free"]
             return data
         else:


### PR DESCRIPTION
Which displayed an error when the vg is full, like:

vagrant@c10n1:/$ om pool status
name        type       caps                 head                                               vols  size   used   free
|- ...
|- drbd1    unknown                         err: invalid literal for int() with base 10: '0k'  0     -      -      -
`- ...