### PR TITLE
Avoid repeating push-to-collector errlogs

### DIFF
--- a/opensvc/daemon/collector.py
+++ b/opensvc/daemon/collector.py
@@ -143,7 +143,10 @@ class Collector(shared.OsvcThread):
     def do(self):
         self.reload_config()
         self.init_collector()
-        if shared.NODE.collector.disabled():
+        if shared.NODE.collector_env.uuid == "":
+            # don't even queue
+            pass
+        elif shared.NODE.collector.disabled():
             self.queue_limit()
         else:
             self.run_collector()


### PR DESCRIPTION
When dbopensvc is set, and the collector is not "disabled()", and the
node is not registered yet (no node.uuid).

Don't even queue messages in this case: consider that situation as a
bootstrap transient state.