### PR TITLE
Fix a 3PARdata scsi pr oddity

### DIFF
--- a/opensvc/core/objects/builder.py
+++ b/opensvc/core/objects/builder.py
@@ -169,12 +169,19 @@ def add_mandatory_syncs(svc):
         kwargs["options"] += svc.conf_get(kwargs["rid"], "options")
     except ex.OptNotFound:
         pass
+    try:
+        kwargs["schedule"] = svc.conf_get(kwargs["rid"], "schedule")
+    except ex.OptNotFound:
+        kwargs["schedule"] = "@60m"
+    try:
+        kwargs["sync_max_delay"] = svc.conf_get(kwargs["rid"], "sync_max_delay")
+    except ex.OptNotFound:
+        kwargs["sync_max_delay"] = 3660
     kwargs["reset_options"] = svc.oget(kwargs["rid"], "reset_options")
     kwargs["target"] = list(target)
     kwargs["internal"] = True
     kwargs["disabled"] = get_disabled(svc, kwargs["rid"])
     kwargs["optional"] = get_optional(svc, kwargs["rid"])
-    kwargs.update(sync_kwargs(svc, kwargs["rid"]))
     r = mod.SyncRsync(**kwargs)
     svc += r
 

--- a/opensvc/drivers/resource/disk/scsireserv/sg.py
+++ b/opensvc/drivers/resource/disk/scsireserv/sg.py
@@ -32,6 +32,8 @@ def driver_capabilities(node=None):
     return data
 
 class DiskScsireservSg(BaseDiskScsireserv):
+    reg_pp = None
+
     def scsireserv_supported(self):
         if not self.has_capability("disk.scsireserv"):
             self.status_log("sg_persist or mpathpersist must be installed to use scsi-3 reservations")
@@ -156,7 +158,7 @@ class DiskScsireservSg(BaseDiskScsireserv):
 
     def get_reg_pp(self, dev):
         did = DiskInfo(deferred=True).disk_id(dev)
-        if not hasattr(self, "reg_pp") or not isinstance(self.reg_pp, dict):
+        if self.reg_pp is None or not isinstance(self.reg_pp, dict):
             try:
                 self.reg_pp = self.var_data_load()["registrations_per_path"]
             except Exception:

--- a/opensvc/drivers/resource/disk/scsireserv/sg.py
+++ b/opensvc/drivers/resource/disk/scsireserv/sg.py
@@ -2,6 +2,7 @@ import os
 import json
 import math
 import re
+import shutil
 import time
 from subprocess import *
 
@@ -107,8 +108,9 @@ class DiskScsireservSg(BaseDiskScsireserv):
         p = self.var_data_dump_path()
         makedirs(os.path.dirname(p))
         self.log.debug("write %s in %s", data, p)
-        with open(p, "w") as f:
+        with open(p+".swp", "w") as f:
             json.dump(data, f, indent=4)
+        shutil.move(p+".swp", p)
 
     @staticmethod
     def read_gen(buff):

--- a/opensvc/drivers/resource/ip/netns/__init__.py
+++ b/opensvc/drivers/resource/ip/netns/__init__.py
@@ -51,7 +51,7 @@ KEYWORDS = [
         "required": False,
         "candidates": ["bridge", "dedicated", "macvlan", "ipvlan-l2", "ipvlan-l3", "ovs"],
         "text": "The ip link mode. If ipdev is set to a bridge interface the mode defaults to bridge, else defaults to macvlan. ipvlan requires a 4.2+ kernel.",
-        "example": "container#0"
+        "example": "ipvlan-l3"
     },
     {
         "keyword": "nsdev",

--- a/opensvc/utilities/subsystems/docker.py
+++ b/opensvc/utilities/subsystems/docker.py
@@ -785,8 +785,19 @@ class DockerLib(ContainerLib):
     def _docker_running_shared(self):
         """
         Return True if the docker daemon is running.
+
+        Old docker daemons return {}.
+        Recent docker daemons return {
+            'ServerErrors': ['Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?'],
+            'ClientInfo': {
+                'Debug': False,
+                'Context': 'default',
+                'Plugins': [],
+                'Warnings': None
+            }
+        }
         """
-        if self.docker_info == {}:
+        if not self.docker_info.get("ServerVersion"):
             return False
         return True
 

--- a/opensvc/utilities/subsystems/docker.py
+++ b/opensvc/utilities/subsystems/docker.py
@@ -170,7 +170,7 @@ class ContainerLib(object):
         try:
             self.docker_exe
         except ex.InitError:
-            return ""
+            return {}
         cmd = [self.docker_exe, "info"] + self.json_opt
         try:
             data = json.loads(justcall(cmd)[0])
@@ -372,12 +372,11 @@ class ContainerLib(object):
         Return the docker drivers keys conttributed to resinfo.
         """
         data = []
-        if "Driver" in self.docker_info:  # pylint: disable=unsupported-membership-test
-            # pylint: disable=unsubscriptable-object
-            data.append(["", "storage_driver", self.docker_info["Driver"]])
-        if "ExecutionDriver" in self.docker_info:  # pylint: disable=unsupported-membership-test
-            # pylint: disable=unsubscriptable-object
-            data.append(["", "exec_driver", self.docker_info["ExecutionDriver"]])
+        di = dict(self.docker_info) # dict cast to please pylint
+        if "Driver" in di:
+            data.append(["", "storage_driver", di["Driver"]])
+        if "ExecutionDriver" in di:
+            data.append(["", "exec_driver", di["ExecutionDriver"]])
         return data
 
     def _docker_info_images(self):
@@ -555,8 +554,8 @@ class DockerLib(ContainerLib):
         else:
             self.docker_pid_file = None
             try:
-                # pylint: disable=unsubscriptable-object
-                set_lazy(self, "container_data_dir", self.docker_info["DockerRootDir"])
+                di = dict(self.docker_info) # dict cast to please pylint
+                set_lazy(self, "container_data_dir", di["DockerRootDir"])
             except (KeyError, TypeError):
                 set_lazy(self, "container_data_dir", None)
 
@@ -797,9 +796,8 @@ class DockerLib(ContainerLib):
             }
         }
         """
-        if not self.docker_info.get("ServerVersion"):
-            return False
-        return True
+        di = dict(self.docker_info) # dict cast to please pylint
+        return di.get("ServerVersion") is not None
 
     def _docker_running_private(self):
         """


### PR DESCRIPTION
Some arrays, like 3PARdata and Clariion, overwrite the registration of a path
with the registration of its failover path.

On a disk accessible via 4 paths (from 2 hba to 2 controlers), after registering
all 4 paths only 2 registrations are reported by "sg_persist -k" instead of 4.

It is not fair to ask the admins to set a keyword to describe the number of
paths per registration to use.

This patch implements:

* on resource start (if not already started), the paths per registration of
each device is computed and stored in a persistant cache file.
  - if unchanged, the cache file is not updated
  - the value is <pr gen delta>/<visible registration>
  - the cache is a map indexed by disk_id (not devpath, which is not stable)

* on resource check, load the cache and use the disk's pp_reg factor to
determine what to expect.

* if the cache file are purged, an info status_log is displayed, explaining
why this particular check is disabled