### PR TITLE
Fix resources presync not executed on "sync* --rid <sync rids>" actions

### DIFF
--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -4671,7 +4671,6 @@ class Svc(PgMixin, BaseSvc):
         ]
         if not self.can_sync(rtypes, 'nodes'):
             return
-        self.presync()
         self.sub_set_action(rtypes, "sync_nodes")
 
     def sync_drp(self):
@@ -4684,7 +4683,6 @@ class Svc(PgMixin, BaseSvc):
         ]
         if not self.can_sync(rtypes, 'drpnodes'):
             return
-        self.presync()
         self.sub_set_action(rtypes, "sync_drp")
 
     def sync_swap(self):
@@ -4827,7 +4825,6 @@ class Svc(PgMixin, BaseSvc):
         if not self.can_sync(["sync"]):
             return
         self.sync_update()
-        self.presync()
         rtypes = [
             "sync.rsync",
             "sync.btrfs",

--- a/opensvc/drivers/resource/sync/rsync/__init__.py
+++ b/opensvc/drivers/resource/sync/rsync/__init__.py
@@ -222,6 +222,7 @@ class SyncRsync(Sync):
         self.timeout = 3600
         self.options = options
         self.reset_options = reset_options
+        self.presync_done = False
 
     def __str__(self):
         return "%s src=%s dst=%s options=%s target=%s" % (
@@ -564,8 +565,19 @@ class SyncRsync(Sync):
     def add_resource_files_to_sync(self):
         if self.rid != "sync#i0":
             return
-        for resource in self.svc.get_resources():
-            self.src += resource.files_to_sync()
+        for r in self.svc.get_resources():
+            self.src += r.files_to_sync()
+        if self.presync_done:
+            return
+        for r in self.svc.get_resources():
+            if r.disabled:
+                continue
+            if r.encap and not self.svc.encap:
+                continue
+            if not hasattr(r, "presync"):
+                continue
+            r.presync()
+        self.presync_done = True
 
     def _info(self):
         self.add_resource_files_to_sync()


### PR DESCRIPTION
Which are the actions submitted by the scheduler daemon thread.

For one visible symptom, a svc with a zpool fails its first sync#i0
"sync all" action with a ".../sub_devs file does not exist" error,
because this file is created by the DiskZpool::presync()