### PR TITLE
Fix base64 encodestring error during register

### DIFF
--- a/opensvc/core/node/node.py
+++ b/opensvc/core/node/node.py
@@ -54,7 +54,7 @@ from utilities.proc import call, justcall, vcall, which, check_privs, daemon_pro
 from utilities.files import assert_file_exists, assert_file_is_root_only_writeable, makedirs
 from utilities.render.color import formatter
 from utilities.storage import Storage
-from utilities.string import bdecode
+from utilities.string import bdecode, base64encode
 
 try:
     from foreign.six.moves.urllib.request import Request, urlopen
@@ -2711,7 +2711,6 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
         """
         Make a request to the collector's rest api
         """
-        import base64
         api = self.collector_api(path=path)
         url = api["url"]
         if not url.startswith("https"):
@@ -2719,10 +2718,7 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
                            "non-encrypted transport")
         request = Request(url+rpath)
         auth_string = '%s:%s' % (api["username"], api["password"])
-        if six.PY3:
-            base64string = base64.encodestring(auth_string.encode()).decode()
-        else:
-            base64string = base64.encodestring(auth_string)
+        base64string = base64encode(auth_string)
         base64string = base64string.replace('\n', '')
         request.add_header("Authorization", "Basic %s" % base64string)
         return request

--- a/opensvc/drivers/array/nexenta.py
+++ b/opensvc/drivers/array/nexenta.py
@@ -5,6 +5,7 @@ import core.exceptions as ex
 from foreign.six.moves.urllib.request import Request, urlopen # pylint: disable=import-error
 from foreign.six.moves.urllib.error import URLError # pylint: disable=import-error
 from utilities.naming import factory, split_path
+from utilities.string import base64encode
 from core.node import Node
 
 class logger(object):
@@ -68,7 +69,7 @@ class Nexenta(object):
         data = {"method": method, "params": params, "object": obj}
         data = json.dumps(data)
         request = Request(self.url, data)
-        base64string = base64.encodestring('%s:%s' % (self.username, self.password))[:-1]
+        base64string = base64encode('%s:%s' % (self.username, self.password))[:-1]
         request.add_header('Authorization', 'Basic %s' % base64string)
         request.add_header('Content-Type' , 'application/json')
         try:

--- a/opensvc/utilities/string/__init__.py
+++ b/opensvc/utilities/string/__init__.py
@@ -1,14 +1,16 @@
 import foreign.six as six
 import base64
 
+
 def base64encode(buff):
     """
     base64.encodestring has been deprecated in Python 3.1 and removed from Python 3.9
     """
     if six.PY3:
-        base64string = base64.encodebytes(buff.encode()).decode()
+        base64string = base64.encodebytes(buff.encode()).decode()  # pylint: disable=no-member
     else:
-        base64string = base64.encodestring(buff)
+        # noinspection PyDeprecation
+        base64string = base64.encodestring(buff)  # pylint: disable=no-member
     return base64string
 
 
@@ -40,7 +42,7 @@ def try_decode(string, codecs=None):
     for i in codecs:
         try:
             return string.decode(i)
-        except:
+        except Exception:
             pass
     return string
 
@@ -65,4 +67,3 @@ def is_glob(text):
     if len(set(text) & set("?*[")) > 0:
         return True
     return False
-

--- a/opensvc/utilities/string/__init__.py
+++ b/opensvc/utilities/string/__init__.py
@@ -1,4 +1,16 @@
 import foreign.six as six
+import base64
+
+def base64encode(buff):
+    """
+    base64.encodestring has been deprecated in Python 3.1 and removed from Python 3.9
+    """
+    if six.PY3:
+        base64string = base64.encodebytes(buff.encode()).decode()
+    else:
+        base64string = base64.encodestring(buff)
+    return base64string
+
 
 def bencode(buff):
     """


### PR DESCRIPTION
* Python version: 3.9
* Error message: module 'base64' has no attribute 'encodestring'
* Root cause: base64.encodestring() and base64.decodestring(), aliases deprecated since Python 3.1, have been removed: use base64.encodebytes() and base64.decodebytes() instead.