### PR TITLE
Abort CRM start actions on svc with unmet hard affinities

### DIFF
--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -34,7 +34,7 @@ from utilities.fcache import fcache
 from utilities.files import makedirs
 from utilities.lazy import lazy, set_lazy, unset_all_lazy, unset_lazy
 from utilities.naming import (fmt_path, resolve_path, svc_pathcf, svc_pathetc,
-                              svc_pathlog, svc_pathtmp, svc_pathvar, new_id, factory)
+                              svc_pathlog, svc_pathtmp, svc_pathvar, new_id, factory, split_path)
 from utilities.proc import (action_triggers, drop_option, find_editor,
                             init_locale, justcall, lcall, vcall)
 from utilities.storage import Storage
@@ -2351,6 +2351,10 @@ class BaseSvc(Crypt, ExtConfigMixin):
         """
         action_triggers(self, trigger, action, **kwargs)
 
+    def availstatus(self):
+        data = self.print_status_data(mon_data=False, refresh=False)
+        return core.status.Status(data.get("avail", "n/a")).value()
+
     def status(self):
         """
         Return the aggregate status a service.
@@ -4581,6 +4585,30 @@ class Svc(PgMixin, BaseSvc):
         self.sub_set_action(START_GROUPS, "set_unprovisioned")
 
     def abort_start(self):
+        self.abort_start_drivers()
+        self.abort_start_affinity()
+
+    def abort_start_affinity(self):
+        if self.running_action != "start":
+            return
+        if self.options.force or os.environ.get("OSVC_ACTION_ORIGIN") == "daemon":
+            # allow CRM actions originating from the daemon
+            # allow CRM actions with --force
+            return
+        for path in self.hard_affinity:
+            name, namespace, kind = split_path(path)
+            svc = factory(kind)(name, namespace, volatile=True, node=self.node)
+            s = svc.availstatus()
+            if s not in (core.status.UP, core.status.NA):
+                raise ex.Error("hard affinity with %s is not satisfied (currently %s). use --force if you really want to start" % (path, core.status.status_str(s)))
+        for path in self.hard_anti_affinity:
+            name, namespace, kind = split_path(path)
+            svc = factory(kind)(name, namespace, volatile=True, node=self.node)
+            s = svc.availstatus()
+            if s not in (core.status.DOWN, core.status.STDBY_UP, core.status.STDBY_DOWN, core.status.NA):
+                raise ex.Error("hard anti affinity with %s is not satisfied (currently %s). use --force if you really want to start" % (path, core.status.status_str(s)))
+
+    def abort_start_drivers(self):
         """
         Give a chance to all resources concerned by the action to voice up
         their rebutal of the action before it begins.

--- a/opensvc/daemon/shared.py
+++ b/opensvc/daemon/shared.py
@@ -1193,7 +1193,7 @@ class OsvcThread(threading.Thread, Crypt):
         def discard_hard_anti_affinity(nodename):
             if not svc.hard_anti_affinity:
                 return False
-            for path in svc.hard_affinity:
+            for path in svc.hard_anti_affinity:
                 try:
                     status = self.nodes_data.get([nodename, "services", "status", path, "avail"])
                 except KeyError:


### PR DESCRIPTION
unless --force is specified, or unless the action originates from the daemon.

Anti-affinity example:

*/svc/*                          qad11c18n1  qad11c18n2
 svc1      up!           1/1   | O!^         X!
 svc2      down!         0/1   | X^          X!

root@qad11c18n1:~# om svc2 start --local
...
E hard anti affinity with svc1 is not satisfied (currently up). use --force if you really want to start
  skip rollback start: no resource activated

Affinity example:

*/svc/*                          qad11c18n1  qad11c18n2
 svc1      up!           1/1   | X!^         X!
 svc2      down!         0/1   | X^          X!

root@qad11c18n1:~# om svc2 start --local
...
E hard affinity with svc1 is not satisfied (currently down). use --force if you really want to start
  skip rollback start: no resource activated