### PR TITLE
Wake up the scheduler thread for a run_scheduler() upon obj config fi…

### DIFF
--- a/opensvc/daemon/monitor.py
+++ b/opensvc/daemon/monitor.py
@@ -3287,6 +3287,7 @@ class Monitor(shared.OsvcThread, MonitorObjectOrchestratorManualMixin):
                         self.service_status(path)
                 except OSError:
                     pass
+                shared.reconfigure_scheduler()
             with shared.SERVICES_LOCK:
                 scope = sorted(list(shared.SERVICES[path].peers))
             config[path] = {

--- a/opensvc/daemon/scheduler.py
+++ b/opensvc/daemon/scheduler.py
@@ -111,7 +111,8 @@ class Scheduler(shared.OsvcThread):
             now = time.time()
             done = self.janitor_procs()
             self.janitor_run_done()
-            if done or last + SCHEDULE_INTERVAL <= now:
+            if done or last + SCHEDULE_INTERVAL <= now or shared.SCHED_RECONF.is_set():
+                shared.SCHED_RECONF.clear()
                 last = now
                 self.janitor_certificates(now)
                 self.janitor_blacklist()

--- a/opensvc/daemon/shared.py
+++ b/opensvc/daemon/shared.py
@@ -139,6 +139,7 @@ DEFERRED_SET_SMON_LOCK = threading.RLock()
 DAEMON_STOP = threading.Event()
 MON_TICKER = threading.Condition()
 COLLECTOR_TICKER = threading.Condition()
+SCHED_RECONF = threading.Event()
 SCHED_TICKER = threading.Condition()
 HB_TX_TICKER = threading.Condition()
 
@@ -244,6 +245,15 @@ def wake_scheduler():
     """
     Notify the scheduler thread to do they periodic job immediatly
     """
+    with SCHED_TICKER:
+        SCHED_TICKER.notify_all()
+
+
+def reconfigure_scheduler():
+    """
+    Notify the scheduler thread to do they periodic job immediatly
+    """
+    SCHED_RECONF.set()
     with SCHED_TICKER:
         SCHED_TICKER.notify_all()
 


### PR DESCRIPTION
…le change

The monitor thread discovers those obj config changes early (via status.json
updates). This patch notifies the scheduler thread when that event occurs
so if a schedule changed the scheduler thread can reconfigure asap.