### PR TITLE
Move the scheduler logs in their own node.scheduler.log file

### DIFF
--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -2249,6 +2249,7 @@ class BaseSvc(Crypt, ExtConfigMixin):
 
         todo = [
           ('INC', os.path.join(Env.paths.pathlog, "node.log")),
+          ('INC', os.path.join(Env.paths.pathlog, "node.scheduler.log")),
           ('INC', os.path.join(Env.paths.pathlog, "xmlrpc.log")),
           ('INC', os.path.join(self.log_d, self.name+".log")),
           ('INC', self.var_d),

--- a/opensvc/daemon/collector.py
+++ b/opensvc/daemon/collector.py
@@ -229,9 +229,9 @@ class Collector(shared.OsvcThread):
 
     def send_daemon_status(self, data):
         if self.last_status_changed:
-            self.log.info("send daemon status, %d changes", len(self.last_status_changed))
+            self.log.debug("send daemon status, %d changes", len(self.last_status_changed))
         else:
-            self.log.info("send daemon status, resync")
+            self.log.debug("send daemon status, resync")
         try:
             shared.NODE.collector.call("push_daemon_status", data, list(self.last_status_changed))
         except Exception as exc:


### PR DESCRIPTION
And stop stream logging, so journalctl is not flooded by scheduler logs.
Same rotation as the other log files.
Add node.scheduler.log to the "support" tarball.

With this patch, the collector thread is now the most frequent logger
in node.log. Change the "send daemon status" message to debug.