### PR TITLE
Fix wrong resource status after start for resource in a // subset

### DIFF
--- a/opensvc/core/resourceset.py
+++ b/opensvc/core/resourceset.py
@@ -333,6 +333,10 @@ class ResourceSet(object):
                 if action == "provision" and resource.type == "volume":
                     # need reset lazy in current process, (subprocess reset lazy has no effect)
                     resource.post_provision_reset_lazy()
+                if action in ("stop", "start", "provision", "unprovision") and hasattr(resource, "is_up_clear_cache"):
+                    # need reset lazy in current process, (subprocess reset lazy has no effect)
+                    # for ex: docker caches container_id, dockerlib caches the ps data, etc...
+                    getattr(resource, "is_up_clear_cache")()
             if len(err) > 0:
                 raise ex.Error("%s non-optional resources jobs returned "
                                "with error" % ",".join(err))


### PR DESCRIPTION
For // subsets, resource actions are run in separate process.

If an action unset lazy props, this unset is not effective in the parent
process, so at the end of the action, when the parent process computes the
post-action instance status, the lingering lazy props can produce invalid
status.

This issue happens reliably with docker containers in a // subset.

This patch detects the presence of a normalized cache cleanup method in the
resource, and calls that after the // process joins, .. for state changing
action only.