### PR TITLE
Fix "om mon" renderer to handle missing flex_target information

### DIFF
--- a/opensvc/core/extconfig.py
+++ b/opensvc/core/extconfig.py
@@ -828,7 +828,7 @@ class ExtConfigMixin(object):
                 val = self.handle_reference(ref, scope=scope,
                                             impersonate=impersonate,
                                             cd=cd, section=section,
-                                            stack=[]+(stack or []))
+                                            stack=stack)
             except ex.NotSupported:
                 val = OPEN + ref + CLOSE
             except ex.NotAvailable:
@@ -957,10 +957,14 @@ class ExtConfigMixin(object):
 
         # 1st try: supported keyword
         try:
-            return self._conf_get(s, o, t=t, scope=scope,
+            _val = self._conf_get(s, o, t=t, scope=scope,
                                   impersonate=impersonate,
                                   use_default=use_default, cd=cd,
                                   section=section, rtype=rtype, stack=stack)
+            if _val is not None:
+                # allow x repeats of valid ref
+                stack.pop()
+            return _val
         except ex.RequiredOptNotFound:
             if deprecated_keywords is None:
                 if verbose:
@@ -974,10 +978,14 @@ class ExtConfigMixin(object):
         exc = False
         for deprecated_keyword in deprecated_keywords:
             try:
-                return self._conf_get(s, deprecated_keyword, t=t, scope=scope,
+                _val = self._conf_get(s, deprecated_keyword, t=t, scope=scope,
                                       impersonate=impersonate,
                                       use_default=use_default, cd=cd,
                                       section=section, rtype=rtype, stack=stack)
+                if _val is not None:
+                    # allow x repeats of valid ref
+                    stack.pop()
+                return _val
             except ex.RequiredOptNotFound:
                 exc = True
         if exc:

--- a/opensvc/core/extconfig.py
+++ b/opensvc/core/extconfig.py
@@ -828,7 +828,7 @@ class ExtConfigMixin(object):
                 val = self.handle_reference(ref, scope=scope,
                                             impersonate=impersonate,
                                             cd=cd, section=section,
-                                            stack=stack)
+                                            stack=[]+(stack or []))
             except ex.NotSupported:
                 val = OPEN + ref + CLOSE
             except ex.NotAvailable:

--- a/opensvc/drivers/array/hds.py
+++ b/opensvc/drivers/array/hds.py
@@ -301,7 +301,7 @@ class Array(object):
         out, err, ret = self.cmd(cmd, scoped=scoped)
         tree = fromstring(out)
         data = []
-        for elem in tree.getiterator("StorageArray"):
+        for elem in tree.iter("StorageArray"):
             data.append(elem.attrib)
         return data
 
@@ -315,14 +315,14 @@ class Array(object):
         out, err, ret = self.cmd(cmd)
         tree = fromstring(out)
         data = []
-        for e_lu in tree.getiterator("LogicalUnit"):
+        for e_lu in tree.iter("LogicalUnit"):
             lu = e_lu.attrib
             lu["Path"] = []
-            for e_path in e_lu.getiterator("Path"):
+            for e_path in e_lu.iter("Path"):
                 lu["Path"].append(e_path.attrib)
-            for e_ldev in e_lu.getiterator("LDEV"):
+            for e_ldev in e_lu.iter("LDEV"):
                 ldev = e_ldev.attrib
-                for e_label in e_ldev.getiterator("ObjectLabel"):
+                for e_label in e_ldev.iter("ObjectLabel"):
                     lu["label"] = e_label.attrib["label"]
             data.append(lu)
         return data
@@ -363,7 +363,7 @@ class Array(object):
         out, err, ret = self.cmd(cmd)
         tree = fromstring(out)
         data = []
-        for elem in tree.getiterator("Pool"):
+        for elem in tree.iter("Pool"):
             data.append(elem.attrib)
         return data
 
@@ -379,7 +379,7 @@ class Array(object):
         out, err, ret = self.cmd(cmd)
         tree = fromstring(out)
         data = []
-        for elem in tree.getiterator("ArrayGroup"):
+        for elem in tree.iter("ArrayGroup"):
             data.append(elem.attrib)
         return data
 
@@ -391,7 +391,7 @@ class Array(object):
         out, err, ret = self.cmd(cmd)
         tree = fromstring(out)
         data = []
-        for elem in tree.getiterator("Port"):
+        for elem in tree.iter("Port"):
             port = elem.attrib
             port["worldWidePortName"] = port["worldWidePortName"].replace(".", "").lower()
             data.append(port)
@@ -409,15 +409,15 @@ class Array(object):
         out, err, ret = self.cmd(cmd)
         tree = fromstring(out)
         data = []
-        for elem in tree.getiterator("HostStorageDomain"):
+        for elem in tree.iter("HostStorageDomain"):
             d = elem.attrib
             d["WWN"] = []
             d["Path"] = []
-            for subelem in elem.getiterator("WWN"):
+            for subelem in elem.iter("WWN"):
                 wwn = subelem.attrib
                 wwn["WWN"] = wwn["WWN"].replace(".", "").lower()
                 d["WWN"].append(wwn)
-            for subelem in elem.getiterator("Path"):
+            for subelem in elem.iter("Path"):
                 path = subelem.attrib
                 d["Path"].append(path)
             data.append(d)

--- a/opensvc/drivers/array/symmetrix.py
+++ b/opensvc/drivers/array/symmetrix.py
@@ -287,7 +287,7 @@ class Arrays(object):
                 print(err, file=sys.stderr)
                 continue
             tree = fromstring(out)
-            for symm in tree.getiterator('Symm_Info'):
+            for symm in tree.iter('Symm_Info'):
                 model = symm.find('model').text
                 if model.startswith('VMAX'):
                     self.arrays.append(Vmax(name, symcli_path, symcli_connect, username, password, node=self.node))
@@ -494,7 +494,7 @@ class SymMixin(object):
                         d[e.tag] = e.text
             return d
 
-        for elem in tree.getiterator(key):
+        for elem in tree.iter(key):
             data.append(parse_elem(elem, as_list, exclude))
 
         return data

--- a/opensvc/drivers/resource/container/kvm/__init__.py
+++ b/opensvc/drivers/resource/container/kvm/__init__.py
@@ -287,7 +287,7 @@ class ContainerKvm(BaseContainer):
                 f.close()
 
         # check if drp flag is already set up
-        for disk in tree.getiterator("disk"):
+        for disk in tree.iter("disk"):
             e = disk.find('source')
             if e is None:
                 continue
@@ -326,7 +326,7 @@ class ContainerKvm(BaseContainer):
             tree.parse(self.cf)
         except Exception as exc:
             return data
-        for dev in tree.getiterator('disk'):
+        for dev in tree.iter('disk'):
             s = dev.find('source')
             if s is None:
                  continue

--- a/opensvc/drivers/resource/disk/drbd/__init__.py
+++ b/opensvc/drivers/resource/disk/drbd/__init__.py
@@ -230,7 +230,7 @@ class DiskDrbd(Resource):
             tree = fromstring(self.dump_xml())
         except Exception:
             return
-        for res in tree.getiterator("resource"):
+        for res in tree.iter("resource"):
             if res.attrib["name"] != self.res:
                 continue
             return res
@@ -240,14 +240,14 @@ class DiskDrbd(Resource):
         res = self.res_xml()
         if res is None:
             return set()
-        for host in res.getiterator("host"):
+        for host in res.iter("host"):
             if host.attrib["name"] != Env.nodename:
                 continue
             d = host.find("device")
             if d is not None:
                 devps |= set([d.text])
                 continue
-            for volume in res.getiterator("volume"):
+            for volume in res.iter("volume"):
                 d = volume.find("device")
                 if d is None:
                     continue
@@ -259,7 +259,7 @@ class DiskDrbd(Resource):
         res = self.res_xml()
         if res is None:
             return set()
-        for host in res.getiterator("host"):
+        for host in res.iter("host"):
             if host.attrib["name"] != Env.nodename:
                 continue
             d = host.find("disk")

--- a/opensvc/drivers/resource/disk/vdisk/__init__.py
+++ b/opensvc/drivers/resource/disk/vdisk/__init__.py
@@ -65,7 +65,7 @@ class DiskVdisk(Resource):
         except:
             self.log.error("failed to parse %s"%self.svc.resources_by_id['container'].cf)
             raise ex.Error
-        for dev in tree.getiterator('disk'):
+        for dev in tree.iter('disk'):
             s = dev.find('source')
             if s is None:
                  continue

--- a/opensvc/tests/commands/svc/test_references.py
+++ b/opensvc/tests/commands/svc/test_references.py
@@ -94,7 +94,7 @@ REFS = [  # (name, value, expected_evaluated_value),
     ("baz", "abc", "abc"),
     ("bar", "{baz}ref", "abcref"),
     ("foo_bar_ref", "a={bar} b={bar} c={bar}",  "a=abcref b=abcref c=abcref"),
-    ("foo_bar_ref_max", " ".join(["{bar}"] * int(MAX_RECURSION / 4)), " ".join(["abcref"] * int(MAX_RECURSION / 4))),
+    ("foo_bar_ref_max", " ".join(["{bar}"] * int(MAX_RECURSION * 40)), " ".join(["abcref"] * int(MAX_RECURSION * 40))),
 ]
 
 ref_names = [key[0] for key in REFS]

--- a/opensvc/tests/commands/svc/test_references.py
+++ b/opensvc/tests/commands/svc/test_references.py
@@ -59,6 +59,8 @@ REFS = [  # (name, value, expected_evaluated_value),
     ("no_change_mixed1", "{aBcDe}", "{aBcDe}"),
     ("no_change_mixed2", "{FOO1..2}", "{FOO1..2}"),
     ("no_change_mixed3", "{{{FOO1..2}}}", "{{{FOO1..2}}}"),
+    ("repeat_item", "repeat_value", "repeat_value"),
+    ("repeat_100_ref", " ".join(["{repeat_item}"]*100), " ".join(["repeat_value"]*100)),
 
     # modifiers
     ("mod_upper", "{upper:clustername}", "DEFAULT"),
@@ -178,6 +180,7 @@ class TestReferencesConfigValidate(object):
             ["priority = 14"],
             ["priority = {env.prio}", "[env]", "prio = 12"],
             ["priority = {env.prio}", "[env]", "prio = 12", "[fs#1]", "type = flag"],
+            ["[env]", "a = foo", "multiple = %s" % " ".join(["{a}"]*40)],
     ))
     def test_validate_config_detect_valid_priority_config(lines):
         config_lines = ['[DEFAULT]', 'id = %s' % ID]

--- a/opensvc/utilities/devtree/linux.py
+++ b/opensvc/utilities/devtree/linux.py
@@ -403,7 +403,7 @@ class DevTree(DevTreeVeritas, BaseDevTree):
             return
         from xml.etree import ElementTree as etree
         tree = etree.fromstring(out.decode())
-        for res in tree.getiterator('resource'):
+        for res in tree.iter('resource'):
             for host in res.findall('host'):
                 if host.attrib['name'] != Env.nodename:
                     continue

--- a/opensvc/utilities/render/cluster/__init__.py
+++ b/opensvc/utilities/render/cluster/__init__.py
@@ -327,7 +327,8 @@ def format_cluster(paths=None, node=None, data=None, prev_stats_data=None,
                 "status": "",
             }
         elif topology == "flex":
-            info["status"] = "%d/%d" % (data["n_up"], data["flex_target"])
+            flex_target = str(data["flex_target"]) if data["flex_target"] else "#"
+            info["status"] = "%d/%s" % (data["n_up"], flex_target)
         if data["avail"] == "n/a":
             info["status"] = ""
         info = "%(orchestrate)-5s %(status)-5s" % info


### PR DESCRIPTION
This can happen when a cluster is partially migrated from 1.9 to 2.1