### PR TITLE
Support labels in capabilities

### DIFF
--- a/opensvc/utilities/diskinfo/linux.py
+++ b/opensvc/utilities/diskinfo/linux.py
@@ -137,17 +137,6 @@ class DiskInfo(BaseDiskInfo):
             s = self._scsi_id(dev, ["-p", "pre-spc3-83"])
         return s
 
-    @lazy
-    def scsi_id_path(self):
-        if which('scsi_id'):
-            return 'scsi_id'
-        elif which('/lib/udev/scsi_id'):
-            return '/lib/udev/scsi_id'
-        elif which('/usr/lib/udev/scsi_id'):
-            return '/usr/lib/udev/scsi_id'
-        else:
-            return None
-
     def _scsi_id(self, dev, args=None):
         if args is None:
             args = []
@@ -156,16 +145,10 @@ class DiskInfo(BaseDiskInfo):
             return wwid
         if dev in self.disk_ids:
             return self.disk_ids[dev]
-<<<<<<< HEAD
-        if not self.scsi_id_path:
-            return
-        cmd = [self.scsi_id_path, '-g', '-u'] + args + ['-d', dev]
-=======
         scsi_id = capabilities.get("node.x.scsi_id.path")
         if not scsi_id:
             return ""
         cmd = [scsi_id, '-g', '-u'] + args + ['-d', dev]
->>>>>>> 5af297321 (Support labels in capabilities)
         out, err, ret = justcall(cmd)
         if ret == 0:
             id = out.split('\n')[0]
@@ -176,7 +159,7 @@ class DiskInfo(BaseDiskInfo):
             self.disk_ids[dev] = id
             return id
         sdev = dev.replace("/dev/", "/block/")
-        cmd = [self.scsi_id_path, '-g', '-u'] + args + ['-s', sdev]
+        cmd = [scsi_id, '-g', '-u'] + args + ['-s', sdev]
         out, err, ret = justcall(cmd)
         if ret == 0:
             id = out.split('\n')[0]

--- a/opensvc/utilities/diskinfo/linux.py
+++ b/opensvc/utilities/diskinfo/linux.py
@@ -13,9 +13,10 @@ import utilities.devtree.veritas
 import utilities.devices.linux
 from .diskinfo import BaseDiskInfo
 
+from core.capabilities import capabilities
 from env import Env
 from utilities.lazy import lazy
-from utilities.proc import justcall, which
+from utilities.proc import justcall
 
 class DiskInfo(BaseDiskInfo):
     disk_ids = {}
@@ -69,9 +70,8 @@ class DiskInfo(BaseDiskInfo):
     def cciss_id(self, dev):
         if dev in self.disk_ids:
             return self.disk_ids[dev]
-        if which('cciss_id'):
-            cciss_id = 'cciss_id'
-        else:
+        cciss_id = capabilities.get("node.x.cciss.path")
+        if not cciss_id:
             return ""
         cmd = [cciss_id, dev]
         out, err, ret = justcall(cmd)
@@ -127,7 +127,7 @@ class DiskInfo(BaseDiskInfo):
         if hasattr(self, "mpath_h"):
             return self.mpath_h
         self.mpath_h = {}
-        if which(Env.syspaths.multipath):
+        if capabilities.has("node.x.multipath"):
             self.load_mpath_native()
         return self.mpath_h
 
@@ -156,9 +156,16 @@ class DiskInfo(BaseDiskInfo):
             return wwid
         if dev in self.disk_ids:
             return self.disk_ids[dev]
+<<<<<<< HEAD
         if not self.scsi_id_path:
             return
         cmd = [self.scsi_id_path, '-g', '-u'] + args + ['-d', dev]
+=======
+        scsi_id = capabilities.get("node.x.scsi_id.path")
+        if not scsi_id:
+            return ""
+        cmd = [scsi_id, '-g', '-u'] + args + ['-d', dev]
+>>>>>>> 5af297321 (Support labels in capabilities)
         out, err, ret = justcall(cmd)
         if ret == 0:
             id = out.split('\n')[0]


### PR DESCRIPTION
Up to now, capabilities were a list of tags.

This patch adds a labels to capabilities, with a label being a key=value
pair.

Use labels for storing detected path for binaries (node.x.<exe>.path).

Optimize utilities.diskinfo with this method.

The caps cache and human rendered caps flattens tags and labels in a
single list, where labels are rendered as key=val.

Example:

...
drivers.resource.sync.rsync.xattrs
drivers.resource.task.docker
drivers.resource.task.docker.registry_creds
drivers.resource.task.host
node.x.blkid
node.x.blkid.path=/sbin/blkid
...