### PR TITLE
Add a max_peers provisioning keyword to disk.drbd

### DIFF
--- a/opensvc/core/node/nodedict.py
+++ b/opensvc/core/node/nodedict.py
@@ -1109,6 +1109,14 @@ Arbitrators can be tested using :cmd:`om node ping --node <arbitrator name>`.
     },
     {
         "section": "pool",
+        "rtype": "drbd",
+        "keyword": "max_peers",
+        "convert": "integer",
+        "default": 0,
+        "text": "The number of drbd peer nodes to configure in the metadata. The default value allows growing x2."
+    },
+    {
+        "section": "pool",
         "rtype": "zpool",
         "keyword": "name",
         "required": True,

--- a/opensvc/drivers/pool/drbd.py
+++ b/opensvc/drivers/pool/drbd.py
@@ -20,6 +20,10 @@ class Pool(BasePool):
         return self.oget("zpool")
 
     @lazy
+    def max_peers(self):
+        return self.oget("max_peers")
+
+    @lazy
     def path(self):
         return self.oget("path") or os.path.join(Env.paths.pathvar, "pool", self.name)
 
@@ -44,6 +48,8 @@ class Pool(BasePool):
                 "disk": "/dev/%s/%s" % (self.vg, name),
                 "standby": True,
             }
+            if self.max_peers != 0:
+                disk["max_peers"] = self.max_peers
             data.append(disk)
             dev = "disk#2"
         elif self.zpool:
@@ -64,6 +70,8 @@ class Pool(BasePool):
                 "disk": "/dev/%s/%s" % (self.zpool, name),
                 "standby": True,
             }
+            if self.max_peers != 0:
+                disk["max_peers"] = self.max_peers
             data.append(disk)
             dev = "disk#2"
         else:
@@ -82,6 +90,8 @@ class Pool(BasePool):
                 "name": name,
                 "standby": True,
             }
+            if self.max_peers != 0:
+                disk["max_peers"] = self.max_peers
             data.append(disk)
             disk = {
                 "rtype": "disk",
@@ -101,6 +111,8 @@ class Pool(BasePool):
                 "disk": "/dev/%s/lv" % name,
                 "standby": True,
             }
+            if self.max_peers != 0:
+                disk["max_peers"] = self.max_peers
             data.append(disk)
             dev = "disk#4"
 

--- a/opensvc/drivers/resource/disk/drbd/__init__.py
+++ b/opensvc/drivers/resource/disk/drbd/__init__.py
@@ -47,7 +47,7 @@ KEYWORDS = BASE_KEYWORDS + [
         "convert": "integer",
         "default": 0,
         "default_text": "(nodes_count*2)-1",
-        "text": "The integer value to use in create-md --max-peers"
+        "text": "The integer value to use in create-md --max-peers. The driver ensures the value is not lesser than the number of instances."
     },
     {
         "keyword": "addr",
@@ -586,12 +586,13 @@ class DiskDrbd(Resource):
         Return the value to use in create-md --max-peers
         """
         v = self.oget("max_peers")
-        min_v = len(self.svc.nodes)
+        n_nodes = len(self.svc.nodes)
+        min_v = n_nodes - 1
         if min_v < 1:
             min_v = 1
         max_v = MAX_NODES - 1
         if v == 0:
-            v = (min_v * 2) - 1
+            v = (n_nodes * 2) - 1
         if v < min_v:
             v = min_v
         if v > max_v:


### PR DESCRIPTION
And set a sane default value, allowing doubling the number of peers for
server migration scenarios.

Changing max peers on a created drbd involves a device resize and
metadata location change, with downtime. Better to waste some space and
avoid that situation.