### PR TITLE
Fix double eval of encap monitored resources

### DIFF
--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -4146,7 +4146,7 @@ class Svc(PgMixin, BaseSvc):
             raise ex.EncapUnjoinable
         if "resource_monitor" in cmd:
             try:
-                self.encap_json_status(container, refresh=True, push_config=False, cache=False)
+                self.encap_json_status(container, refresh=False, push_config=False, cache=False)
             except (ex.NotAvailable, ex.EncapUnjoinable, ex.Error):
                 pass
         elif "print" not in cmd and "create" not in cmd:


### PR DESCRIPTION
The encap json status cache file is updated from
_encap_cmd("resource_monitor"), but the routine handling that cache
refresh was called with refresh=True, meaning the global agent executes
a "print status --refresh" in the container.

This is useless and wasteful. Use refresh=False