### PR TITLE
Fix parallel set/unset/delete keywords

### DIFF
--- a/opensvc/core/extconfig.py
+++ b/opensvc/core/extconfig.py
@@ -192,6 +192,7 @@ class ExtConfigMixin(object):
         """
         Delete config file sections.
         """
+        self.cd_clear_caches()
         if sections is None:
             sections = []
         try:
@@ -224,6 +225,7 @@ class ExtConfigMixin(object):
         self.unset_multi(kws)
 
     def unset_multi(self, kws):
+        self.cd_clear_caches()
         try:
             cd = self.private_cd
         except AttributeError:
@@ -353,6 +355,7 @@ class ExtConfigMixin(object):
             return self.set_mono(eval=eval)
 
     def set_multi(self, kws, eval=False, validation=True):
+        self.cd_clear_caches()
         try:
             cd = self.private_cd
         except AttributeError:
@@ -403,6 +406,7 @@ class ExtConfigMixin(object):
         self._set_multi(changes, validation=validation)
 
     def set_mono(self, eval=False):
+        self.cd_clear_caches()
         try:
             cd = self.private_cd
         except AttributeError:

--- a/opensvc/core/node/node.py
+++ b/opensvc/core/node/node.py
@@ -215,6 +215,10 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
             configs.append(Env.paths.nodeconf)
         return self.parse_config_file(configs)
 
+    def cd_clear_caches(self):
+        self.raw_cd = None
+        self.unset_lazy("cd")
+
     @lazy
     def private_cd(self):
         return self.parse_config_file(self.paths.cf)

--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -790,6 +790,10 @@ class BaseSvc(Crypt, ExtConfigMixin):
             return self.raw_cd
         return self.parse_config_file(self.paths.cf)
 
+    def cd_clear_caches(self):
+        self.raw_cd = None
+        self.unset_lazy("cd")
+
     @lazy
     def disabled(self):
         return self.oget("DEFAULT", "disable")


### PR DESCRIPTION
The set/unset/delete acquire a lock but at this point the process has
already cached the configuration to amend, so only the last ending
process change actually remains.

This patch adds a cache refresh in the locked section of these actions
code paths.