### PR TITLE
Fix the listener socket bind on ipv6-disabled hosts

### DIFF
--- a/opensvc/core/comm.py
+++ b/opensvc/core/comm.py
@@ -519,7 +519,7 @@ class Crypt(object):
         node = self.get_node()
         addr = node.oget("listener", "tls_addr", impersonate=nodename)
         port = node.oget("listener", "tls_port", impersonate=nodename)
-        if nodename != Env.nodename and addr in ("0.0.0.0", "::"):
+        if nodename != Env.nodename and addr in ("0.0.0.0", "::", ""):
             addr = nodename
             port = 1214
         return addr, port

--- a/opensvc/core/node/nodedict.py
+++ b/opensvc/core/node/nodedict.py
@@ -664,9 +664,9 @@ If not set, or set to ``true``, the reboot flag is removed before reboot, and a 
     {
         "section": "listener",
         "keyword": "tls_addr",
-        "default": "::",
+        "default": "",
         "example": "1.2.3.4",
-        "text": "The ip addr the daemon tls listener must listen on."
+        "text": "The ip addr the daemon tls listener must listen on. The empty value used as default means: all ip4 and ip6."
     },
     {
         "section": "listener",
@@ -678,9 +678,9 @@ If not set, or set to ``true``, the reboot flag is removed before reboot, and a 
     {
         "section": "listener",
         "keyword": "addr",
-        "default": "::",
+        "default": "",
         "example": "1.2.3.4",
-        "text": "The ip addr the daemon raw listener must listen on."
+        "text": "The ip addr the daemon raw listener must listen on. The empty value used as default means: all ip4 and ip6."
     },
     {
         "section": "listener",


### PR DESCRIPTION
Change the listener.addr and listener.tls_addr default value to "",
instead of "::", and implement the following {tls_}addr policy:

 ::      => listen on all ipv6 addrs (using AF_INET6 and IPV6_V6ONLY=1)
 0.0.0.0 => listen on all ipv4 addrs
 <empty> => listen on all ipv4 and ipv6 addrs (using AF_INET6 and IPV6_V6ONLY=0)