### PR TITLE
Don't error an action if the end_action rpc call fails

### DIFF
--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -1307,9 +1307,13 @@ class BaseSvc(Crypt, ExtConfigMixin):
         Send to the collector the service status after an action, and
         the action log.
         """
-        self.node.daemon_collector_xmlrpc('end_action', self.path, action,
-                                          begin, end, self.options.cron,
-                                          actionlogfile)
+        try:
+            self.node.daemon_collector_xmlrpc("end_action", self.path, action,
+                                              begin, end, self.options.cron,
+                                              actionlogfile)
+        except Exception as exc:
+            self.log.warning("failed to send logs to the collector: %s", exc)
+
         try:
             logging.shutdown()
         except:

--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -1329,9 +1329,14 @@ class BaseSvc(Crypt, ExtConfigMixin):
         begin = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
         # Provision a database entry to store action log later
-        self.node.daemon_collector_xmlrpc("begin_action", self.path,
-                                          action, self.node.agent_version,
-                                          begin, self.options.cron)
+        try:
+            self.node.daemon_collector_xmlrpc("begin_action", self.path,
+                                              action, self.node.agent_version,
+                                              begin, self.options.cron)
+        except Exception as exc:
+            self.log.warning("failed to init logs on the collector: %s", exc)
+            self.log_action_header(action, options)
+            return self.do_action(action, options)
 
         # Per action logfile to push to database at the end of the action
         tmpfile = tempfile.NamedTemporaryFile(delete=False, dir=Env.paths.pathtmp,


### PR DESCRIPTION
For example the collector might return an error due to a dup svc.
In any case, we don't want to consider a collector info push error as an
action error.

This patch log the issue as a warning and proceed.