### PR TITLE
Fix a stack building object with encap tasks and DEFAULT.restart set

### DIFF
--- a/opensvc/core/objects/builder.py
+++ b/opensvc/core/objects/builder.py
@@ -39,10 +39,18 @@ def get_subset(svc, section, impersonate=None):
     return svc.oget(section, "subset", impersonate=impersonate)
 
 def get_restart(svc, section, impersonate=None):
-    return svc.oget(section, "restart", impersonate=impersonate)
+    try:
+        return svc.oget(section, "restart", impersonate=impersonate)
+    except ValueError:
+        # tasks don't support restart
+        return 0
 
 def get_restart_delay(svc, section, impersonate=None):
-    return svc.oget(section, "restart_delay", impersonate=impersonate)
+    try:
+        return svc.oget(section, "restart_delay", impersonate=impersonate)
+    except ValueError:
+        # tasks don't support restart_delay
+        return 0
 
 def get_disabled(svc, section, impersonate=None):
     return svc.oget(section, "disable", impersonate=impersonate)


### PR DESCRIPTION
The object builder prepares a dict for encap resource, impersonating the
encap node to evaluate some base keywords.

Restart and restart_delay are such keywords, but they are no longer
valid keywords of tasks, causing a stack.

Catch the ValueError emitted by extconfig and fallback to a zero value.