### PR TITLE
Remove lvmetad condition for pvscan --cache

### DIFF
--- a/opensvc/drivers/resource/disk/vg/linux.py
+++ b/opensvc/drivers/resource/disk/vg/linux.py
@@ -154,16 +154,8 @@ class DiskVg(BaseDisk):
         (ret, out, err) = self.vcall(cmd)
         self.clear_cache("vg.tags")
 
-    @lazy
-    def has_metad(self):
-        cmd = ["pgrep", "lvmetad"]
-        out, err, ret = justcall(cmd)
-        return ret == 0
-
     def pvscan(self):
-        cmd = ["pvscan"]
-        if self.has_metad:
-            cmd += ["--cache"]
+        cmd = ["pvscan", "--cache"]
         ret, out, err = self.vcall(cmd, warn_to_info=True)
         self.clear_cache("vg.lvs")
         self.clear_cache("lvs.attr")


### PR DESCRIPTION
* lvmetad has been removed from lvm since 2018

https://github.com/lvmteam/lvm2/commit/117160b27e510dceb1ed6acf995115c040acd88d