### PR TITLE
[api] Fix possible errors during GET /object/confirmations

### DIFF
--- a/opensvc/daemon/handlers/object/confirmations/get.py
+++ b/opensvc/daemon/handlers/object/confirmations/get.py
@@ -1,4 +1,5 @@
 import daemon.handler
+import daemon.shared as shared
 
 from utilities.naming import split_path, factory
 
@@ -28,7 +29,7 @@ class Handler(daemon.handler.BaseHandler):
     def action(self, nodename, thr=None, **kwargs):
         options = self.parse_options(kwargs)
         name, namespace, kind = split_path(options.path)
-        svc = factory(kind)(name=name, namespace=namespace, volatile=True)
+        svc = factory(kind)(name=name, namespace=namespace, volatile=True, node=shared.NODE)
         data = {
             "status": 0,
             "data": [res.rid for res in svc.get_resources("task") if res.confirmation],


### PR DESCRIPTION
Traceback (most recent call last):

      File "/usr/share/opensvc/opensvc/daemon/listener.py", line 1735, in do_node
        _result = handler.action(nodename, action=action, options=options, stream_id=stream_id, thr=self)
      File "/usr/share/opensvc/opensvc/daemon/handlers/object/confirmations/get.py", line 34, in action
        "data": [res.rid for res in svc.get_resources("task") if res.confirmation],
      File "/usr/share/opensvc/opensvc/core/objects/svc.py", line 3544, in get_resources
        self.init_resources()
      File "/usr/share/opensvc/opensvc/core/objects/svc.py", line 3521, in init_resources
        self.init_resources_errors = add_resources(self)
      File "/usr/share/opensvc/opensvc/core/objects/builder.py", line 232, in add_resources
        add_resource(svc, restype, section)
      File "/usr/share/opensvc/opensvc/core/objects/builder.py", line 132, in add_resource
        kwargs = svc.section_kwargs(s)
      File "/usr/share/opensvc/opensvc/core/extconfig.py", line 1570, in section_kwargs
        kwargs[keyword.protoname] = self.conf_get(section, keyword.keyword, rtype=rtype, verbose=False)
      File "/usr/share/opensvc/opensvc/core/extconfig.py", line 972, in conf_get
        _val = self._conf_get(s, o, t=t, scope=scope,
      File "/usr/share/opensvc/opensvc/core/extconfig.py", line 1058, in _conf_get
        return self.__conf_get(s, o, **kwargs)
      File "/usr/share/opensvc/opensvc/core/extconfig.py", line 1108, in __conf_get
        val = self.handle_references(val, scope=scope,
      File "/usr/share/opensvc/opensvc/core/extconfig.py", line 879, in handle_references
        val = self._handle_references(s, scope=scope,
      File "/usr/share/opensvc/opensvc/core/extconfig.py", line 837, in _handle_references
        val = self.handle_reference(ref, scope=scope,
      File "/usr/share/opensvc/opensvc/core/extconfig.py", line 633, in handle_reference
        val = "%s.%s.%s.%s" % (self.name, ns, self.kind, self.node.cluster_name)