### PR TITLE
Fix "daemon shutdown" and "node drain" considering the svc shutdown i…

### DIFF
--- a/opensvc/daemon/handlers/daemon/shutdown/post.py
+++ b/opensvc/daemon/handlers/daemon/shutdown/post.py
@@ -66,7 +66,7 @@ class Handler(daemon.handler.BaseHandler):
 
     def wait_shutdown(self, thr=None):
         def still_shutting(thr=None):
-            if self.has_deferred_set_smon():
+            if thr.has_deferred_set_smon():
                 return True
             for path, smon in thr.iter_local_services_monitors():
                 if smon.local_expect == "shutdown":

--- a/opensvc/daemon/handlers/daemon/shutdown/post.py
+++ b/opensvc/daemon/handlers/daemon/shutdown/post.py
@@ -66,6 +66,8 @@ class Handler(daemon.handler.BaseHandler):
 
     def wait_shutdown(self, thr=None):
         def still_shutting(thr=None):
+            if self.has_deferred_set_smon():
+                return True
             for path, smon in thr.iter_local_services_monitors():
                 if smon.local_expect == "shutdown":
                     return True

--- a/opensvc/daemon/handlers/node/drain/post.py
+++ b/opensvc/daemon/handlers/node/drain/post.py
@@ -70,7 +70,7 @@ class Handler(daemon.handler.BaseHandler):
 
     def wait_shutdown(self, timeout=None, thr=None):
         def still_shutting():
-            if self.has_deferred_set_smon():
+            if thr.has_deferred_set_smon():
                 return True
             for path, smon in thr.iter_local_services_monitors():
                 if smon.local_expect == "shutdown":

--- a/opensvc/daemon/handlers/node/drain/post.py
+++ b/opensvc/daemon/handlers/node/drain/post.py
@@ -70,6 +70,8 @@ class Handler(daemon.handler.BaseHandler):
 
     def wait_shutdown(self, timeout=None, thr=None):
         def still_shutting():
+            if self.has_deferred_set_smon():
+                return True
             for path, smon in thr.iter_local_services_monitors():
                 if smon.local_expect == "shutdown":
                     return True

--- a/opensvc/daemon/shared.py
+++ b/opensvc/daemon/shared.py
@@ -655,12 +655,13 @@ class OsvcThread(threading.Thread, Crypt):
             self.node_data.set(["monitor"], nmon)
             wake_monitor(reason="node mon change")
 
-    def has_deferred_set_smon(
+    @staticmethod
+    def has_deferred_set_smon():
         with DEFERRED_SET_SMON_LOCK:
             return len(DEFERRED_SET_SMON) > 0
 
+    @staticmethod
     def defer_set_smon(
-            self,
             path, status=None, local_expect=None, global_expect=None,
             reset_retries=False, stonith=None, expected_status=None,
             origin=""):

--- a/opensvc/daemon/shared.py
+++ b/opensvc/daemon/shared.py
@@ -655,6 +655,10 @@ class OsvcThread(threading.Thread, Crypt):
             self.node_data.set(["monitor"], nmon)
             wake_monitor(reason="node mon change")
 
+    def has_deferred_set_smon(
+        with DEFERRED_SET_SMON_LOCK:
+            return len(DEFERRED_SET_SMON) > 0
+
     def defer_set_smon(
             self,
             path, status=None, local_expect=None, global_expect=None,


### PR DESCRIPTION
…s done

When they actually are not.

This bug is due to the defer_set_smon() staged shutdown local_expect is
not detected by the wait loops in these 2 codepaths.