### PR TITLE
Improve mpathpersist configuration pattern detection

### DIFF
--- a/opensvc/drivers/resource/disk/scsireserv/sg.py
+++ b/opensvc/drivers/resource/disk/scsireserv/sg.py
@@ -1,5 +1,6 @@
 import os
 import time
+import re
 
 import core.exceptions as ex
 from core.capabilities import capabilities
@@ -30,7 +31,7 @@ def driver_capabilities(node=None):
 
             def mpathpersist_enabled_in_conf(output):
                 for conf_line in output.splitlines():
-                    if "reservation_key file" in conf_line:
+                    if re.search(r'reservation_key\s+["]file["]', conf_line) is not None:
                         return True
                 return False
 

--- a/opensvc/drivers/resource/disk/scsireserv/sg.py
+++ b/opensvc/drivers/resource/disk/scsireserv/sg.py
@@ -31,7 +31,7 @@ def driver_capabilities(node=None):
 
             def mpathpersist_enabled_in_conf(output):
                 for conf_line in output.splitlines():
-                    if re.search(r'reservation_key\s+["]file["]', conf_line) is not None:
+                    if re.search(r'reservation_key\s+["]{0,1}file["]{0,1}', conf_line) is not None:
                         return True
                 return False
 

--- a/opensvc/drivers/resource/disk/scsireserv/sg.py
+++ b/opensvc/drivers/resource/disk/scsireserv/sg.py
@@ -15,6 +15,13 @@ ACK_UNIT_ATTENTION_RETRY_MAX = 10
 ACK_UNIT_ATTENTION_RETRY_DELAY = 0.1
 
 
+def mpathpersist_enabled_in_conf(output):
+    for conf_line in output.splitlines():
+        if re.search(r'^\s*reservation_key\s+("|)?file\1\s*$', conf_line) is not None:
+            return True
+    return False
+
+
 # noinspection PyUnusedLocal
 def driver_capabilities(node=None):
     data = []
@@ -28,13 +35,6 @@ def driver_capabilities(node=None):
             version = [int(v) for v in line.split()[1].strip("v").split(".")]
             break
         if version > [0, 7, 8]:
-
-            def mpathpersist_enabled_in_conf(output):
-                for conf_line in output.splitlines():
-                    if re.search(r'reservation_key\s+["]{0,1}file["]{0,1}', conf_line) is not None:
-                        return True
-                return False
-
             def multipath_get_conf():
                 conf_output, _, exit_code = justcall(["multipathd", "show", "config"])
                 if exit_code == 0:

--- a/opensvc/tests/resource/disk/scsireserv/test_disk_scsireserv.py
+++ b/opensvc/tests/resource/disk/scsireserv/test_disk_scsireserv.py
@@ -1,5 +1,6 @@
 import pytest
 
+from drivers.resource.disk.scsireserv.sg import mpathpersist_enabled_in_conf
 from tests.helpers import assert_resource_has_mandatory_methods
 
 
@@ -23,3 +24,47 @@ class TestDriverDiskScsireservInstances:
     @staticmethod
     def test_has_mandatory_methods(create_driver_resource, sysname, scenario):
         assert_resource_has_mandatory_methods(create_driver_resource(sysname, scenario))
+
+
+@pytest.mark.ci
+@pytest.mark.parametrize('config, expected', [
+    [' reservation_key file', True],
+    ['reservation_key file', True],
+    ['reservation_key file ', True],
+    ['reservation_key  file ', True],
+    ['reservation_key\tfile', True],
+    ['reservation_key\tfile\t', True],
+    ['reservation_key "file"', True],
+    ['reservation_key \t"file"', True],
+    ['reservation_key\t"file"', True],
+    ['reservation_key\t"file" ', True],
+    ['reservation_key\t"file"\t', True],
+    ['reservation_key\t"file"\t ', True],
+    ['reservation_key \t"file"\t ', True],
+    ['reservation_key "file" ', True],
+    ['reservation_key  "file" ', True],
+    ['reservation_key  "file"  ', True],
+    ['reservation_key    "file"     ', True],
+
+    ['', False],
+    ['\n\n', False],
+    ['_reservation_key file', False],
+    ['reservation_key file a', False],
+    ['reservation_key file a ', False],
+    ['reservation_key "file" a', False],
+    ['reservation_key "file" a ', False],
+    ['reservation_key "file', False],
+    ['reservation_key "file ', False],
+    ['reservation_key  "file ', False],
+    ['reservation_key file"', False],
+    ['reservation_key file" ', False],
+    ['reservation_key filea', False],
+    ['reservation_key file-', False],
+    ['reservation_key file"', False],
+    ['reservation_key  "filea" ', False],
+])
+class TestMpathPersistEnabledInConf:
+    @staticmethod
+    def test_mpathpersist_enabled_in_conf(config, expected):
+        assert mpathpersist_enabled_in_conf(config) is expected, \
+            "mpathpersist_enabled_in_conf expected %s when config is \n%s" % (expected, config)


### PR DESCRIPTION
root@qau18c20n1:~# grep -i pretty /etc/os-release
PRETTY_NAME="Ubuntu 18.04.6 LTS"
root@qau18c20n1:~# multipath -v 2>&1 | grep ^multipath-tools
multipath-tools v0.7.4 (11/15, 2017)
root@qau18c20n1:~# multipathd show config|grep reser
	reservation_key file

root@demo1:~# grep -i pretty /etc/os-release
PRETTY_NAME="Ubuntu 20.04.4 LTS"
root@demo1:~# multipath -v 2>&1 | grep ^multipath-tools
multipath-tools v0.8.3 (10/02, 2019)
root@demo1:~# multipathd show config|grep reser
	reservation_key file

root@qau22c13n1:~# grep -i pretty /etc/os-release
PRETTY_NAME="Ubuntu 22.04 LTS"
root@qau22c13n1:~# multipath -v 2>&1 | grep ^multipath-tools
multipath-tools v0.8.8 (03/12, 2021)
root@qau22c13n1:~# multipathd show config|grep reser
	reservation_key "file"