### PR TITLE
Fix cgroup stack

### DIFF
--- a/opensvc/drivers/pg/linux.py
+++ b/opensvc/drivers/pg/linux.py
@@ -384,7 +384,9 @@ def thaw(o):
     return freezer(o, "THAWED")
 
 def pids(o, controller="memory"):
-    cgp = get_cgroup_path(o, controller)
+    cgp = get_cgroup_path(o, controller, create=False)
+    if not os.path.exists(cgp):
+        return []
     _pids = set()
     fname = "cgroup.procs"
     for path, _, files in os.walk(cgp):


### PR DESCRIPTION
2022-07-04 08:24:01,039000 INFO    sid:f18f87fa-b862-44bc-8118-85b613afe578 n:qau22c13n2 o:system/vol/c13envoy1-data sc:n | /bin/echo +cpuset +cpu +io +memory +pids >/sys/fs/cgroup/opensvc.slice/system.slice/c13envoy1-data.slice/cgroup.subtree_control
2022-07-04 08:24:01,039000 ERROR   sid:f18f87fa-b862-44bc-8118-85b613afe578 n:qau22c13n2 o:system/vol/c13envoy1-data sc:n | a stack has been saved in the logs
FileNotFoundError: [Errno 2] No such file or directory
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/share/opensvc/opensvc/core/objects/svc.py", line 1149, in do_action
    err = call_action(action)
  File "/usr/share/opensvc/opensvc/core/objects/svc.py", line 1138, in call_action
    err = getattr(self, action)()
  File "/usr/share/opensvc/opensvc/core/objects/svc.py", line 4528, in stop
    self.master_stop()
  File "/usr/share/opensvc/opensvc/core/objects/svc.py", line 492, in _func
    func(self)
  File "/usr/share/opensvc/opensvc/core/objects/svc.py", line 4533, in master_stop
    self.pg_remove()
  File "/usr/share/opensvc/opensvc/core/objects/pg.py", line 78, in pg_remove
    self.pg_kill()
  File "/usr/share/opensvc/opensvc/core/objects/pg.py", line 153, in pg_kill
    self._pg_kill()
  File "/usr/share/opensvc/opensvc/core/objects/pg.py", line 57, in _pg_kill
    return self._pg_freezer("kill")
  File "/usr/share/opensvc/opensvc/core/objects/pg.py", line 72, in _pg_freezer
    self.pg.kill(self)
  File "/usr/share/opensvc/opensvc/drivers/pg/linux.py", line 403, in kill
    _pids = pids(o, controller="freezer")
  File "/usr/share/opensvc/opensvc/drivers/pg/linux.py", line 387, in pids
    cgp = get_cgroup_path(o, controller)
  File "/usr/share/opensvc/opensvc/drivers/pg/linux.py", line 315, in get_cgroup_path
    create_cgroup(cgp, log=log)
  File "/usr/share/opensvc/opensvc/drivers/pg/linux.py", line 351, in create_cgroup
    set_sysfs(cgp+"/cgroup.subtree_control", "+cpuset +cpu +io +memory +pids", log=log)
  File "/usr/share/opensvc/opensvc/drivers/pg/linux.py", line 377, in set_sysfs
    with open(path, "w") as f:
FileNotFoundError: [Errno 2] No such file or directory