### PR TITLE
Don't choose "lo" network by default in container.podman start codepath

### DIFF
--- a/opensvc/drivers/pg/linux.py
+++ b/opensvc/drivers/pg/linux.py
@@ -384,7 +384,9 @@ def thaw(o):
     return freezer(o, "THAWED")
 
 def pids(o, controller="memory"):
-    cgp = get_cgroup_path(o, controller)
+    cgp = get_cgroup_path(o, controller, create=False)
+    if not os.path.exists(cgp):
+        return []
     _pids = set()
     fname = "cgroup.procs"
     for path, _, files in os.walk(cgp):

--- a/opensvc/drivers/resource/container/docker/__init__.py
+++ b/opensvc/drivers/resource/container/docker/__init__.py
@@ -805,7 +805,7 @@ class ContainerDocker(BaseContainer):
                     raise ex.Error("resource %s, referenced in %s.netns, does not exist" % (self.netns, self.rid))
             else:
                 args += ["--net=" + self.netns]
-        elif not has_option("--net", args):
+        elif not has_option("--net", args) and self.default_net:
             args += ["--net=" + self.default_net]
 
         if self.pidns:

--- a/opensvc/drivers/resource/container/podman/__init__.py
+++ b/opensvc/drivers/resource/container/podman/__init__.py
@@ -57,7 +57,7 @@ class ContainerPodman(ContainerDocker):
     """
     Docker container resource driver.
     """
-    default_net = "lo"
+    default_net = ""
     dns_option_option = "--dns-opt"
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
We previously chose "lo", but this network does no longer exists by
default. Just don't set --net, so the first available network is chosen.