### PR TITLE
Delete docker container by id

### DIFF
--- a/opensvc/drivers/resource/container/docker/__init__.py
+++ b/opensvc/drivers/resource/container/docker/__init__.py
@@ -534,11 +534,13 @@ class ContainerDocker(BaseContainer):
         """
         Remove the resource docker instance.
         """
+        if self.container_id is None:
+            return
         if not self.lib.docker_running():
             return
         if self.lib.docker_cmd is None:
             raise ex.Error("docker executable not found")
-        cmd = self.lib.docker_cmd + ['rm', self.container_name]
+        cmd = self.lib.docker_cmd + ['rm', self.container_id]
         out, err, ret = justcall(cmd)
         if ret != 0:
             if "No such container" in err:


### PR DESCRIPTION
Instead of by name.

So changing the container name keyword value when the container is up
does not the break rm=true behaviour.