### PR TITLE
Fix py2 lcall logging with non utf-8 characters

### DIFF
--- a/opensvc/utilities/proc/__init__.py
+++ b/opensvc/utilities/proc/__init__.py
@@ -160,9 +160,7 @@ def lcall(cmd, logger, outlvl=logging.INFO, errlvl=logging.ERROR, timeout=None, 
             return logged
         for io in rlist:
             buff = os.read(io, 32768)
-            buff = bdecode(buff)
-            if six.PY2:
-                buff = buff.decode("utf8")
+            buff = buff.decode("utf-8", "ignore")
             if buff in ('', b''):
                 continue
             buff = pending[io] + buff


### PR DESCRIPTION
Just filter them out, via .decode("utf8", "ignore").

Tested with a starter app script like:

	#!/bin/bash
	echo "foöé"
	dd if=/dev/urandom bs=1k count=1

And a resource:

	[app#1]
	start = /root/echob