### PR TITLE
Fix the mpathpersist capability scanner

### DIFF
--- a/opensvc/drivers/resource/disk/scsireserv/sg.py
+++ b/opensvc/drivers/resource/disk/scsireserv/sg.py
@@ -22,6 +22,14 @@ def mpathpersist_enabled_in_conf(output):
     return False
 
 
+def parse_version(buff):
+    for line in buff.splitlines():
+        try:
+            return [int(v) for v in line.split()[1].strip("v").split(".")]
+        except Exception:
+            continue
+    return [0, 0, 0]
+
 # noinspection PyUnusedLocal
 def driver_capabilities(node=None):
     data = []
@@ -29,11 +37,8 @@ def driver_capabilities(node=None):
         data.append("disk.scsireserv")
         data.append("disk.scsireserv.sg_persist")
     if which("mpathpersist"):
-        version = [0, 0, 0]
-        out, err, ret = justcall(["multipath", "-h"])
-        for line in err.splitlines():
-            version = [int(v) for v in line.split()[1].strip("v").split(".")]
-            break
+        _, err, ret = justcall(["multipath", "-h"])
+        version = parse_version(err)
         if version > [0, 7, 8]:
             def multipath_get_conf():
                 conf_output, _, exit_code = justcall(["multipathd", "show", "config"])


### PR DESCRIPTION
The multipath -h parser was broken by the deprecation warnings. For example, in this text:

166693.618823 | /etc/multipath.conf line 5, "multipath_dir" is deprecated and will be disabled in a future release 166693.618872 | /etc/multipath.conf line 23, "bindings_file" is deprecated and will be disabled in a future release 166693.618877 | /etc/multipath.conf line 24, "wwids_file" is deprecated and will be disabled in a future release multipath-tools v0.8.8 (03/12, 2021)
Usage:
  multipath [-v level] [-B|-d|-i|-q|-r] [-b file] [-p policy] [device]
  multipath [-v level] [-R retries] -f device
  multipath [-v level] [-R retries] -F