### PR TITLE
Fix the ip.cni provisioned status

### DIFF
--- a/opensvc/drivers/resource/ip/cni/__init__.py
+++ b/opensvc/drivers/resource/ip/cni/__init__.py
@@ -555,6 +555,6 @@ class IpCni(IpHost):
             return False
         return True
 
-    def provisioned(self):
-        return True
+    def is_provisioned(self):
+        return
 

--- a/opensvc/drivers/resource/ip/cni/__init__.py
+++ b/opensvc/drivers/resource/ip/cni/__init__.py
@@ -555,6 +555,6 @@ class IpCni(IpHost):
             return False
         return True
 
-    def is_provisioned(self):
+    def is_provisioned(self, refresh=False):
         return
 


### PR DESCRIPTION
That was always true, but should be n/a.

Beacause provisioned=True prevent the unprovision orchestration to reach the unprovisioned state.