### PR TITLE
Add a network kw to pool.drbd and disk.drbd

### DIFF
--- a/opensvc/core/node/nodedict.py
+++ b/opensvc/core/node/nodedict.py
@@ -1123,6 +1123,12 @@ Arbitrators can be tested using :cmd:`om node ping --node <arbitrator name>`.
     {
         "section": "pool",
         "rtype": "drbd",
+        "keyword": "network",
+        "text": "The name of the backend network to use for drbd trafic. Set this keyword if some node names are resolved to NATed addresses."
+    },
+    {
+        "section": "pool",
+        "rtype": "drbd",
         "keyword": "vg",
         "text": "The name of the volume group to allocate the pool volumes logical volumes into."
     },

--- a/opensvc/drivers/pool/drbd.py
+++ b/opensvc/drivers/pool/drbd.py
@@ -24,6 +24,10 @@ class Pool(BasePool):
         return self.oget("max_peers")
 
     @lazy
+    def network(self):
+        return self.oget("network")
+
+    @lazy
     def path(self):
         return self.oget("path") or os.path.join(Env.paths.pathvar, "pool", self.name)
 
@@ -48,6 +52,8 @@ class Pool(BasePool):
                 "disk": "/dev/%s/%s" % (self.vg, name),
                 "standby": True,
             }
+            if self.network:
+                disk["network"] = self.network
             if self.max_peers != 0:
                 disk["max_peers"] = self.max_peers
             data.append(disk)
@@ -70,6 +76,8 @@ class Pool(BasePool):
                 "disk": "/dev/%s/%s" % (self.zpool, name),
                 "standby": True,
             }
+            if self.network:
+                disk["network"] = self.network
             if self.max_peers != 0:
                 disk["max_peers"] = self.max_peers
             data.append(disk)
@@ -111,6 +119,8 @@ class Pool(BasePool):
                 "disk": "/dev/%s/lv" % name,
                 "standby": True,
             }
+            if self.network:
+                disk["network"] = self.network
             if self.max_peers != 0:
                 disk["max_peers"] = self.max_peers
             data.append(disk)


### PR DESCRIPTION
If set, the drbd .res file is configured with node ip on the backend network pointed by name, instead of the getaddr(nodename).

This setup can be used to benefit from ipip tunnels configured by the backend network drivers, to allow drbd to communicate between NATed hosts (for example GCE-hosted nodes).