### PR TITLE
Fix a case of lxc config file location set to None

### DIFF
--- a/opensvc/drivers/resource/container/lxc/__init__.py
+++ b/opensvc/drivers/resource/container/lxc/__init__.py
@@ -636,7 +636,7 @@ class ContainerLxc(BaseContainer):
         path = which('lxc-info')
         if path is None:
             return
-        dpath = os.path.dirname(path)
+        dpath = os.path.dirname(os.path.realpath(path))
         if not dpath.endswith("bin"):
             return
         dpath = os.path.realpath(os.path.join(dpath, ".."))


### PR DESCRIPTION
When lxc-info is resolved to a non standard located symlink (<HOME>/bin/ for ex) the lxc config file ends up being None.

Follow the symlink before trying to format the config file location from lxc-info location.