### PR TITLE
Fix node.oci evaluating as "None" instead of either docker or podman

### DIFF
--- a/opensvc/core/extconfig.py
+++ b/opensvc/core/extconfig.py
@@ -873,6 +873,9 @@ class ExtConfigMixin(object):
 
     def handle_references(self, s, scope=False, impersonate=None, cd=None,
                           section=None, stack=None):
+        if s is None:
+            # avoid cache key collision with "None" values (typically node.dbopensvc)
+            return
         key = self.ref_cache_key(s, scope, impersonate)
         if key and key in self.ref_cache:
             return self.ref_cache[key]


### PR DESCRIPTION
If node.dbopensvc=None in the node.conf, chances are that this kw is evaluated before node.oci during object actions.

In this case, the "None" value is stored in the dereference cache with key="...None". Then when node.oci is evaluated the same key is formatted and "None" is returned from the cache instead of the expected None (NoneType).

This patch implements a shortcut for dereferencing None. In this case alway return None, without looking at the cache.