### PR TITLE
Apply some obfuscation to the daemon listener responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,10 @@ jobs:
           OPENSVC_CI_EXTRA_TIME_OSVCD_STARTUP: 25
         run: sudo $(which pytest) ${{ matrix.PYTEST_EXTRA_ARGS }} -m "ci"
 
-      - name: Run codecov
-        if: ${{ success() }}
+      - name: Run coverage report
+        if: ${{ success() && matrix.PYTEST_EXTRA_ARGS == '--cov' }}
         run: |
-          pip install codecov
-          codecov
+          coverage report
 
   ci-pylint:
     runs-on: ubuntu-latest

--- a/opensvc/core/node/nodedict.py
+++ b/opensvc/core/node/nodedict.py
@@ -696,6 +696,13 @@ If not set, or set to ``true``, the reboot flag is removed before reboot, and a 
         "text": "The url serving the well-known configuration of an openid provider. If set, the h2 listener will try to validate the Bearer token provided in the requests. If valid the user name is fetched from the 'preferred_username' claim (fallback on 'name'), and the user grants are fetched from the 'grant' claim. Grant can be a list, in which case a proper grant value is formatted via concatenation of the list elements."
     },
     {
+        "section": "listener",
+        "keyword": "ui",
+        "convert": "boolean",
+        "default": True,
+        "text": "Serve the ui webapp to browsers getting the api / path.",
+    },
+    {
         "section": "syslog",
         "keyword": "facility",
         "default": "daemon",

--- a/opensvc/daemon/handlers/api/get.py
+++ b/opensvc/daemon/handlers/api/get.py
@@ -9,7 +9,10 @@ class Handler(daemon.handler.BaseHandler):
         (None, "get_api"),
     )
     prototype = []
-    access = {}
+    access = {
+      "roles": ["guest"],
+      "namespaces": "ANY",
+    }
 
     def action(self, nodename, thr=None, **kwargs):
         sigs = []

--- a/opensvc/daemon/handlers/keywords/get.py
+++ b/opensvc/daemon/handlers/keywords/get.py
@@ -20,7 +20,10 @@ class Handler(daemon.handler.BaseHandler):
             "desc": "The object kind or 'node'.",
         },
     ]
-    access = {}
+    access = {
+      "roles": ["guest"],
+      "namespaces": "ANY",
+    }
 
     def action(self, nodename, thr=None, **kwargs):
         options = self.parse_options(kwargs)

--- a/opensvc/daemon/listener.py
+++ b/opensvc/daemon/listener.py
@@ -1258,7 +1258,7 @@ class ClientHandler(shared.OsvcThread):
         sending_progress = "sending %s /%s result" % (method, path)
         if path == "favicon.ico":
             self.parent.stats.sessions.alive[self.sid].progress = sending_progress
-            return 200, "image/x-icon", ICON
+            return self.favicon()
         elif path in ("", "index.html"):
             self.parent.stats.sessions.alive[self.sid].progress = sending_progress
             return self.index()
@@ -2116,6 +2116,16 @@ class ClientHandler(shared.OsvcThread):
     # App
     #
     ##########################################################################
+
+    @staticmethod
+    def ui():
+        return shared.NODE.oget("listener", "ui")
+
+    def favicon(self):
+        if not self.ui():
+            return 403, "", ""
+        return 200, "image/x-icon", ICON
+
     def serve_file(self, rpath, content_type):
         try:
             return 200, content_type, self.load_file(rpath)
@@ -2123,10 +2133,14 @@ class ClientHandler(shared.OsvcThread):
             return 404, content_type, "The webapp is not installed."
 
     def index(self):
+        if not self.ui():
+            return 403, "", ""
         #data = self.load_file("index.js")
         #self.h2_push_promise(stream_id, "/index.js", data, "application/javascript")
         return self.serve_file("index.html", "text/html")
 
     def index_js(self):
+        if not self.ui():
+            return 403, "", ""
         return self.serve_file("index.js", "application/javascript")
 


### PR DESCRIPTION
1/ if listener.ui=false do not serve the webapp index.html, index.js and
   favicon.ico

2/ do not serve the api manifest on GET /api if not authenticated

3/ do not serve the keywords manifest on GET /keywords if not authenticated

4/ if the ui is enabled and the user chosed the 'x509' auth method, he could see the api documentation. Now he can't via 2/