### PR TITLE
Don't stop parsing mount output on first line with more than 8 fields

### DIFF
--- a/opensvc/utilities/mounts/linux.py
+++ b/opensvc/utilities/mounts/linux.py
@@ -34,7 +34,7 @@ class Mounts(BaseMounts):
         mounts = []
         for l in out.split('\n'):
             if len(l.split()) != 6:
-                break
+                continue
             dev, null, mnt, null, type, mnt_opt = l.split()
             m = Mount(dev, mnt, type, mnt_opt.strip('()'))
             mounts.append(m)


### PR DESCRIPTION
We don't support dev or mnt with whitespaces, but we shouldn't stop parsing if we encounter some unsupported mount.