### PR TITLE
Fix comp.py import of utilities.uri

### DIFF
--- a/var/compliance/com.opensvc/comp.py
+++ b/var/compliance/com.opensvc/comp.py
@@ -330,7 +330,7 @@ class CompObject(object):
         request = self.collector_request(path)
         if not api["url"].startswith("https"):
             raise ComplianceError("refuse to submit auth tokens through a non-encrypted transport")
-        from utilities.uri import ssl_context_kwargs
+        from utilities import ssl_context_kwargs
         kwargs = ssl_context_kwargs()
         try:
             f = urlopen(request, **kwargs)
@@ -353,7 +353,7 @@ class CompObject(object):
         request = self.collector_request(path)
         if api["url"].startswith("https"):
             raise ComplianceError("refuse to submit auth tokens through a non-encrypted transport")
-        from utilities.uri import ssl_context_kwargs
+        from utilities import ssl_context_kwargs
         kwargs = ssl_context_kwargs()
         try:
             f = urlopen(request, **kwargs)
@@ -394,7 +394,7 @@ class CompObject(object):
 
     def urlretrieve(self, url, fpath):
         request = Request(url)
-        from utilities.uri import ssl_context_kwargs
+        from utilities import ssl_context_kwargs
         kwargs = ssl_context_kwargs()
         f = urlopen(request, **kwargs)
         with open(fpath, 'wb') as df:

--- a/var/compliance/com.opensvc/utilities.py
+++ b/var/compliance/com.opensvc/utilities.py
@@ -21,6 +21,21 @@ def which(program):
             return exe_file
     return None
 
+def ssl_context_kwargs():
+    kwargs = {}
+    try:
+        import ssl
+        if [sys.version_info.major, sys.version_info.minor] >= [3, 10]:
+            # noinspection PyUnresolvedReferences
+            # pylint: disable=no-member
+            kwargs["context"] = ssl._create_unverified_context(protocol=ssl.PROTOCOL_TLS_CLIENT)
+        else:
+            kwargs["context"] = ssl._create_unverified_context()
+        kwargs["context"].set_ciphers("DEFAULT")
+    except (ImportError, AttributeError):
+        pass
+    return kwargs
+
 if __name__ == "__main__":
     print("this file is for import into compliance objects", file=sys.stderr)
 


### PR DESCRIPTION
the var/compliance/com.opensvc where comp.py is hosted already contains a utilities.py module, which confuses utilities.uri import from opensvc/utilities.

Embed a ssl_context_kwargs() definition in
var/compliance/com.opensvc/utilities.py to restore independance of com.opensvc from agent modules.