### PR TITLE
Add node command logger

### DIFF
--- a/bin/init/opensvc.defaults.parameters
+++ b/bin/init/opensvc.defaults.parameters
@@ -14,4 +14,5 @@
 #OSVC_PYTHON=python
 #LD_LIBRARY_PATH=
 #LD_PRELOAD=
+#OSVC_COMMAND_LOG=/var/log/opensvc/node.commands.log
 

--- a/bin/om
+++ b/bin/om
@@ -107,6 +107,11 @@ main() {
 		exec $SUDO $0 "$@"
 		exit
 	fi
+
+	if ! test -z "$OSVC_COMMAND_LOG"
+	then
+		log "$@" >/dev/null 2>&1
+	fi
 	OSVC_CWD=$PWD
 	export OSVC_CWD
 	cd $OSVC_ROOT_PATH
@@ -124,6 +129,23 @@ main() {
 		PYTHONPATH="$OSVC_ROOT_PATH:$PYTHONPATH" $INTER $OSVC_PYTHON_ARGS -m opensvc "$@"
 		;;
 	esac
+}
+
+log() {
+	OSVC_COMMAND_STRING="$0 $@"
+	if ! test -f $OSVC_COMMAND_LOG
+	then
+		touch $OSVC_COMMAND_LOG
+	fi
+	if test -w $OSVC_COMMAND_LOG
+	then
+		GREP=`which grep 2>/dev/null`
+		if test -x "$GREP"
+		then
+			echo "$OSVC_COMMAND_STRING" | $GREP -qE 'sec/|secret' && return
+			$GREP -qxF "$OSVC_COMMAND_STRING" $OSVC_COMMAND_LOG || echo "$OSVC_COMMAND_STRING" >> $OSVC_COMMAND_LOG
+		fi
+	fi
 }
 
 main "$@"


### PR DESCRIPTION
* disabled by default
* set OSVC_COMMAND_LOG=/var/log/opensvc/node.commands.log environment variable to enable the logger
* commands are stored and deduplicated in file pointed by OSVC_COMMAND_LOG variable