### PR TITLE
Add a dblogcron kw

### DIFF
--- a/opensvc/core/node/nodedict.py
+++ b/opensvc/core/node/nodedict.py
@@ -420,7 +420,14 @@ KEYWORDS = [
         "keyword": "dblog",
         "convert": "boolean",
         "default": True,
-        "text": "If true and dbopensvc is set, the objects action logs are reported to the collector. Set to false to disable log reporting to the collector, event if dbopensvc is set."
+        "text": "If true and dbopensvc is set, the objects action logs are reported to the collector. Set to false to disable log reporting to the collector, even if dbopensvc is set."
+    },
+    {
+        "section": "node",
+        "keyword": "dblogcron",
+        "convert": "boolean",
+        "default": True,
+        "text": "If true and dbopensvc is set, the objects croned action logs are reported to the collector. Set to false to disable croned actions log reporting to the collector."
     },
     {
         "section": "node",

--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -1010,8 +1010,15 @@ class BaseSvc(Crypt, ExtConfigMixin):
            action.startswith("json_"):
             return self.do_print_action(action, options)
 
-        if self.published_action(action, options):
+        def is_logged_action():
+            if self.options.cron and not self.node.oget("node", "dblogcron"):
+                return False
             if self.node.oget("node", "dblog") and self.node.collector_env.dbopensvc and self.node.collector_env.uuid:
+                return True
+            return False
+
+        if self.published_action(action, options):
+            if is_logged_action():
                 err = self.do_logged_action(action, options)
             else:
                 self.log_action_header(action, options)


### PR DESCRIPTION
This keyword disables the log sending to the collector for actions running with --cron.

These actions can run at high frequency and make the collector log table bloated and useless.