### PR TITLE
Fix command 'om' regression since 2.1-1676 'Add node command logger' on Solaris

### DIFF
--- a/bin/om
+++ b/bin/om
@@ -108,7 +108,7 @@ main() {
 		exit
 	fi
 
-	if ! test -z "$OSVC_COMMAND_LOG"
+	if [ ! -z "$OSVC_COMMAND_LOG" ]
 	then
 		log "$@" >/dev/null 2>&1
 	fi
@@ -133,7 +133,7 @@ main() {
 
 log() {
 	OSVC_COMMAND_STRING="$0 $@"
-	if ! test -f $OSVC_COMMAND_LOG
+	if [ ! -f "$OSVC_COMMAND_LOG" ]
 	then
 		touch $OSVC_COMMAND_LOG
 	fi

--- a/bin/om
+++ b/bin/om
@@ -139,7 +139,11 @@ log() {
 	fi
 	if test -w $OSVC_COMMAND_LOG
 	then
-		GREP=`which grep 2>/dev/null`
+		if [ "`uname`" = "SunOS" ] ; then
+			GREP=`which ggrep 2>/dev/null`
+		else
+			GREP=`which grep 2>/dev/null`
+		fi
 		if test -x "$GREP"
 		then
 			echo "$OSVC_COMMAND_STRING" | $GREP -qE 'sec/|secret' && return


### PR DESCRIPTION
2.1-1676-gf72943135 f72943135137a5666c5fdc9644688d58a75e40b2  Add node command logger
