### PR TITLE
Remove the obsoleted podman --namespace option usage

### DIFF
--- a/opensvc/utilities/subsystems/docker.py
+++ b/opensvc/utilities/subsystems/docker.py
@@ -860,7 +860,6 @@ class PodmanLib(ContainerLib):
         self.docker_daemon_args = []
         self.docker_daemon_args += [
             "--cgroup-manager", "cgroupfs",
-            "--namespace", self.svc.path,
             "--cni-config-dir", self.svc.node.cni_config,
         ]
 


### PR DESCRIPTION
See containers/podman commit 5c2a0670fcf31dd974e984bcbe4ae7909b6e00ba for this option obsolescence rationale.