### PR TITLE
Make sure we can unset a kw even if having uppercase letters in section

### DIFF
--- a/opensvc/core/comm.py
+++ b/opensvc/core/comm.py
@@ -405,7 +405,7 @@ class Crypt(object):
                 loaded = json.loads(bdecode(data))
             except ValueError as exc:
                 loaded = data
-            if not isinstance(loaded, foreign.six.text_type):
+            if not isinstance(loaded, six.text_type):
                 loaded = data
             return msg_clustername, msg_nodename, loaded
         try:

--- a/opensvc/core/extconfig.py
+++ b/opensvc/core/extconfig.py
@@ -240,10 +240,6 @@ class ExtConfigMixin(object):
             except Exception:
                 section = "DEFAULT"
                 option = kw
-            if 'DEFAULT' not in section:
-                section = section.lower()
-            if section not in ("data", "env"):
-                option = option.lower()
             try:
                 del cd[section][option]
                 deleted += 1
@@ -368,8 +364,6 @@ class ExtConfigMixin(object):
             if "=" not in kw:
                 raise ex.Error("malformed kw expression: %s: no '='" % kw)
             keyword, value = kw.split("=", 1)
-            if 'DEFAULT' not in keyword and not keyword.startswith("data.") and not keyword.startswith("env."):
-                keyword = keyword.lower()
             if keyword[-1] == "-":
                 op = "remove"
                 keyword = keyword[:-1]
@@ -432,8 +426,6 @@ class ExtConfigMixin(object):
             op = "set"
             value = self.options.value
         keyword = self.options.param
-        if 'DEFAULT' not in keyword and not keyword.startswith("data.") and not keyword.startswith("env."):
-            keyword = keyword.lower()
         index = self.options.index
         changes = []
         if "." in keyword and "#" not in keyword:


### PR DESCRIPTION
The "set" codepath makes sure the section is lowercased, but existing configs or configs installed via copy or a text editor may still contain uppercase letters in sections.

This patch also adds a test to warn about such situations via validate config.