### PR TITLE
Fix a reported last boot issue on daylight saving time changes

### DIFF
--- a/opensvc/utilities/asset/asset.py
+++ b/opensvc/utilities/asset/asset.py
@@ -629,27 +629,8 @@ class BaseAsset(object):
         return str(os.path.getmtime("/proc/1"))
 
     def get_last_boot(self):
-        cmd = ["/usr/bin/uptime"]
-        out, err, ret = justcall(cmd)
-        l = out.split()
-
-        i = 0
-        for s in ("days,", "day(s),", "day,", "days", "day"):
-            try:
-                i = l.index(s)
-                break
-            except:
-                pass
-
-        if i == 0:
-            last = datetime.datetime.now()
-        else:
-            try:
-                last = datetime.datetime.now() - datetime.timedelta(days=int(l[i-1]))
-            except:
-                return
-
-        last = last.strftime("%Y-%m-%d")
+        last = os.path.getmtime("/proc/1")
+        last = datetime.datetime.fromtimestamp(last).strftime("%Y-%m-%d %H:%M:%S")
         return {
             "title": "last boot",
             "value": last,

--- a/opensvc/utilities/asset/linux.py
+++ b/opensvc/utilities/asset/linux.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import re
 
@@ -746,6 +747,18 @@ class Asset(BaseAsset):
                     if line.startswith("btime "):
                         return line.split()[-1]
         return super(Asset, self).get_boot_id()
+
+    def get_last_boot(self):
+        with open("/proc/uptime", "r") as f:
+                s = f.readline().split()[0]
+        last = datetime.datetime.now() - datetime.timedelta(seconds=float(s))
+        last = last.replace(microsecond=0)
+        return {
+            "title": "last boot",
+            "value": last,
+            "source": self.s_probe
+        }
+
 
 if __name__ == "__main__":
     from env import Env

--- a/opensvc/utilities/asset/sunos.py
+++ b/opensvc/utilities/asset/sunos.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import re
@@ -288,6 +289,24 @@ class Asset(BaseAsset):
             return self.get_boot_id_zone()
         else:
             return super(Asset, self).get_boot_id()
+
+    def get_last_boot(self):
+        if self.zone:
+            return self.get_last_boot_zone()
+        else:
+            return super(Asset, self).get_last_boot()
+
+    def get_last_boot_zone(self):
+        pid = self.zsched_pid()
+        if pid is None:
+            return
+        last = os.path.getmtime("/proc/%s" % pid)
+        last = datetime.datetime.fromtimestamp(last).strftime("%Y-%m-%d %H:%M:%S")
+        return {
+            "title": "last boot",
+            "value": last,
+            "source": self.s_probe
+        }
 
 if __name__ == "__main__":
     print(Asset()._get_cpu_model())


### PR DESCRIPTION
Don't use the elapsed days count.

On linux use /proc/uptime (seconds elasped).
On other operating systems, use /proc/1 mtime.

Also report a datetime instead of a date, as the collector can now store a datetime.