### PR TITLE
Fix the encap config fetch from container.kvm resources

### DIFF
--- a/opensvc/drivers/resource/container/kvm/__init__.py
+++ b/opensvc/drivers/resource/container/kvm/__init__.py
@@ -164,7 +164,12 @@ class ContainerKvm(BaseContainer):
         return True
 
     def rcp_from(self, src, dst):
-        return "", "", 0
+        if self.qga:
+            # TODO
+            return "", "", 0
+        else:
+            cmd = Env.rcp.split() + [self.name+":"+src, dst]
+            return justcall(cmd)
 
     def rcp(self, src, dst):
         if self.qga:


### PR DESCRIPTION
The container.kvm driver implements a rcp_from method since 2.1-1665, so the svc.py calls it to fetch, but the implementation is a noop.

Implement the scp method in rcp_from.
The qga implementation is marked TODO.