### PR TITLE
Fix the zvol create options order

### DIFF
--- a/opensvc/daemon/monitor.py
+++ b/opensvc/daemon/monitor.py
@@ -2646,6 +2646,7 @@ class Monitor(shared.OsvcThread, MonitorObjectOrchestratorManualMixin):
             candidates = self.placement_candidates(
                 svc, discard_frozen=False,
                 discard_unprovisioned=False,
+                discard_overloaded=False,
             )
         try:
             top = self.placement_ranks(svc, candidates=candidates)[0]

--- a/opensvc/drivers/resource/disk/zvol/__init__.py
+++ b/opensvc/drivers/resource/disk/zvol/__init__.py
@@ -178,9 +178,9 @@ class DiskZvol(BaseDisk):
         if self.has_it():
             self.log.info("zvol %s already exists", self.name)
             return
-        cmd = [Env.syspaths.zfs, "create", "-V"]
+        cmd = [Env.syspaths.zfs, "create"]
         cmd += self.create_options
-        cmd += [str(convert_size(self.size, _to="m"))+'M', self.name]
+        cmd += ["-V", str(convert_size(self.size, _to="m"))+'M', self.name]
         ret, out, err = self.vcall(cmd)
         if ret != 0:
             raise ex.Error


### PR DESCRIPTION
User-defined options were inserted between -V and <size>M.