### PR TITLE
Change the zvol device file to the newer /dev/zvol/<poolname>/<zvolname>

### DIFF
--- a/opensvc/drivers/pool/drbd.py
+++ b/opensvc/drivers/pool/drbd.py
@@ -80,7 +80,7 @@ class Pool(BasePool):
                 "rtype": "disk",
                 "type": "drbd",
                 "res": name,
-                "disk": "/dev/%s/%s" % (self.zpool, name),
+                "disk": "/dev/zvol/%s/%s" % (self.zpool, name),
                 "standby": True,
             }
             if self.network:


### PR DESCRIPTION
zfs changed this location in 0.8.0 to avoid collisions with /dev/<poolname> and existing directories.

The pool.drbd driver was still seting disk=/dev/<poolname>/<zvolname> in the drbd resource of the vol it creates.