### PR TITLE
[driver.pool.freenas] Fix missed exception during provision -> create…

### DIFF
--- a/bin/init/systemd.opensvc-agent.service
+++ b/bin/init/systemd.opensvc-agent.service
@@ -19,6 +19,7 @@ Requires=opensvc-services.service
 [Service]
 Type=forking
 TimeoutStopSec=5m
+ExecStartPost=sleep 0.5
 ExecStart=/usr/share/opensvc/bin/om daemon start
 ExecStop=/usr/share/opensvc/bin/om daemon stop
 KillMode=process

--- a/opensvc/daemon/main.py
+++ b/opensvc/daemon/main.py
@@ -99,12 +99,51 @@ def fork(func, args=None, kwargs=None):
     except Exception:
         os._exit(1)
 
-    # Add delay to ensure parents process exit.
+    # Add delay to ensure process main and fork1 processes exits (that had same args as
+    # opensvc daemon process) before we check daemon pid processes.
     # This prevents daemon start abort on <detect running daemon process (from parents main or fork1 during boot)>
     # PID  DESC
-    # i    main => fork() <defunct>
-    # i+1    fork1 => fork() <defunct>
-    # i+2      fork2 => read <i> from pidfile, check if <i> is alive => abort
+    # i    main => fork() <defunct> level 1: 7966
+    # i+1    fork1 => fork() <defunct> level 2: 7970
+    # i+2      fork2 => read <i> from pidfile, check if <i> is alive => abort level 3: 7971
+    #
+    # log example without delay: when fork2 check if pid exist and match daemon, main pid still exist
+    # => initial start ... failed ... second restart
+    # reproducer ()
+    # {
+    #     echo om daemon stop ...;
+    #     om daemon stop;
+    #     typeset -i add=$1;
+    #     typeset -i last_pid=$(set -- $(ps -o pid=); shift $(($#-1)); echo $1);
+    #     typeset -i pid=add+last_pid;
+    #     echo "set /var/lib/opensvc/osvcd.pid: $pid (from last_pid $last_pid + $add)";
+    #     printf $pid > /var/lib/opensvc/osvcd.pid;
+    #     om daemon start;
+    #     sleep 1;
+    #     echo "got /var/lib/opensvc/osvcd.pid: $(cat /var/lib/opensvc/osvcd.pid)"
+    # }
+    #
+    # reproducer 21
+    # om daemon stop ...
+    # set /var/lib/opensvc/osvcd.pid: 7966 (from last_pid 7945 + 21)
+    # Job for opensvc-agent.service failed because the service did not take the steps required by its unit configuration.
+    # See "systemctl status opensvc-agent.service" and "journalctl -xe" for details.
+    # cat: /var/lib/opensvc/osvcd.pid: No such file or directory
+    # got /var/lib/opensvc/osvcd.pid:
+    #
+    # Apr 02 23:06:20.747801 node1 systemd[1]: Starting OpenSVC agent...
+    # Apr 02 23:06:21.578814 node1 python3[7971]: n:node1 c:main detect running daemon process from /var/lib/opensvc/osvcd.pid: 7966 (our pid/ppid is 7971/1)
+    # Apr 02 23:06:21.579029 node1 python3[7971]: n:node1 c:main abort start: a daemon process is already running
+    # Apr 02 23:06:21.691992 node1 systemd[1]: opensvc-agent.service: New main PID 7966 does not exist or is a zombie.
+    # Apr 02 23:06:21.692214 node1 systemd[1]: opensvc-agent.service: Failed with result 'protocol'.
+    # Apr 02 23:06:21.696758 node1 systemd[1]: Failed to start OpenSVC agent.
+    # Apr 02 23:06:21.947391 node1 systemd[1]: opensvc-agent.service: Service RestartSec=100ms expired, scheduling restart.
+    # Apr 02 23:06:21.947915 node1 systemd[1]: opensvc-agent.service: Scheduled restart job, restart counter is at 1.
+    # Apr 02 23:06:21.948061 node1 systemd[1]: Stopped OpenSVC agent.
+    # Apr 02 23:06:21.949261 node1 systemd[1]: Starting OpenSVC agent...
+    #
+    # it needs systemd ExecStartPost=sleep 0.5 to prevent following systemd warning:
+    #     systemd[1]: opensvc-agent.service: Can't open PID file /var/lib/opensvc/osvcd.pid (yet?) after start: No such file or directory
     time.sleep(0.2)
 
     # Redirect standard file descriptors.

--- a/opensvc/drivers/pool/freenas.py
+++ b/opensvc/drivers/pool/freenas.py
@@ -8,6 +8,7 @@ from core.pool import BasePool
 LOCK_NAME = "freenas_update_disk"
 LOCK_TIMEOUT = 120
 
+
 class Pool(BasePool):
     type = "freenas"
     capabilities = ["roo", "rwo", "rox", "rwx", "shared", "blk", "iscsi"]
@@ -45,21 +46,19 @@ class Pool(BasePool):
         if not mappings:
             raise ex.Error("refuse to create a disk with no mappings")
         lock_id = None
-        result = {}
         try:
             lock_id = self.node._daemon_lock(LOCK_NAME, timeout=LOCK_TIMEOUT, on_error="raise")
             self.log.info("lock acquired: name=%s id=%s", LOCK_NAME, lock_id)
-            result = self.array.add_iscsi_zvol(name=name, size=size,
-                                               volume=self.diskgroup,
-                                               mappings=mappings,
-                                               insecure_tpc=self.insecure_tpc,
-                                               compression=self.compression,
-                                               sparse=self.sparse,
-                                               blocksize=self.blocksize)
+            return self.array.add_iscsi_zvol(name=name, size=size,
+                                             volume=self.diskgroup,
+                                             mappings=mappings,
+                                             insecure_tpc=self.insecure_tpc,
+                                             compression=self.compression,
+                                             sparse=self.sparse,
+                                             blocksize=self.blocksize)
         finally:
             self.node._daemon_unlock(LOCK_NAME, lock_id)
             self.log.info("lock released: name=%s id=%s", LOCK_NAME, lock_id)
-            return result
 
     def translate(self, name=None, size=None, fmt=True, shared=False):
         data = []

--- a/opensvc/drivers/pool/freenas.py
+++ b/opensvc/drivers/pool/freenas.py
@@ -31,15 +31,13 @@ class Pool(BasePool):
 
     def delete_disk(self, name=None, disk_id=None):
         lock_id = None
-        result = {}
         try:
             lock_id = self.node._daemon_lock(LOCK_NAME, timeout=LOCK_TIMEOUT, on_error="raise")
             self.log.info("lock acquired: name=%s id=%s", LOCK_NAME, lock_id)
-            result = self.array.del_iscsi_zvol(name=name, volume=self.diskgroup)
+            return self.array.del_iscsi_zvol(name=name, volume=self.diskgroup)
         finally:
             self.node._daemon_unlock(LOCK_NAME, lock_id)
             self.log.info("lock released: name=%s id=%s", LOCK_NAME, lock_id)
-            return result
 
     def create_disk(self, name, size, nodes=None):
         mappings = self.get_mappings(nodes)


### PR DESCRIPTION
…_disk -> add_iscsi_zvol

With previous code, the raised exception from add_iscsi_zvol was dropped because of the return statement into the finally block

This improves log and don't anymore return {} when add_iscsi_zvol raises

Previous logs:
    # om vol/data provision --local --disable-rollback --leader
    @ n:node1 o:vol/data r:disk#1 sc:n
      mappings for nodes node1,node2: iqn....
      lock acquired: name=freenas_update_disk id=b1189938-05f4-4c4e-ae21-b63ed41b80a0
      lock released: name=freenas_update_disk id=b1189938-05f4-4c4e-ae21-b63ed41b80a0
    E invalid create disk result: {}

New logs:
    # om vol/data provision --local --disable-rollback --leader
    @ n:node1 o:vol/data r:disk#1 sc:n
      mappings for nodes node1,node2: iqn....
      lock acquired: name=freenas_update_disk id=d56525c1-2916-40d0-a25e-dfc6ffb938cb
      lock released: name=freenas_update_disk id=d56525c1-2916-40d0-a25e-dfc6ffb938cb
    E POST http://freenas-addr/api/v2.0/pool/dataset/ {"name": "tank/data.root.vol.clusterxx", "type": "VOLUME", "volsize": 134217728, "sparse": true, "deduplication": "OFF"} => 422: {
     "message": "Failed to create dataset: dataset already exists",
     "errno": 14
    }