### PR TITLE
Fix the hp3par proxy mode query parms

### DIFF
--- a/opensvc/drivers/array/hp3par.py
+++ b/opensvc/drivers/array/hp3par.py
@@ -117,7 +117,7 @@ class Hp3par(object):
         values = {
           'array' : self.name,
           'cmd' : cmd,
-          'path' : self.path,
+          'svcname' : self.path,
           'uuid' : self.uuid,
         }
 


### PR DESCRIPTION
The 'svcname' query parm was renamed to 'path' but the proxy has no been updated to support this.

Revert to 'svcname'.