### PR TITLE
Add the read_only container.docker driver keyword

### DIFF
--- a/opensvc/drivers/pool/freenas.py
+++ b/opensvc/drivers/pool/freenas.py
@@ -8,6 +8,7 @@ from core.pool import BasePool
 LOCK_NAME = "freenas_update_disk"
 LOCK_TIMEOUT = 120
 
+
 class Pool(BasePool):
     type = "freenas"
     capabilities = ["roo", "rwo", "rox", "rwx", "shared", "blk", "iscsi"]
@@ -45,21 +46,19 @@ class Pool(BasePool):
         if not mappings:
             raise ex.Error("refuse to create a disk with no mappings")
         lock_id = None
-        result = {}
         try:
             lock_id = self.node._daemon_lock(LOCK_NAME, timeout=LOCK_TIMEOUT, on_error="raise")
             self.log.info("lock acquired: name=%s id=%s", LOCK_NAME, lock_id)
-            result = self.array.add_iscsi_zvol(name=name, size=size,
-                                               volume=self.diskgroup,
-                                               mappings=mappings,
-                                               insecure_tpc=self.insecure_tpc,
-                                               compression=self.compression,
-                                               sparse=self.sparse,
-                                               blocksize=self.blocksize)
+            return self.array.add_iscsi_zvol(name=name, size=size,
+                                             volume=self.diskgroup,
+                                             mappings=mappings,
+                                             insecure_tpc=self.insecure_tpc,
+                                             compression=self.compression,
+                                             sparse=self.sparse,
+                                             blocksize=self.blocksize)
         finally:
             self.node._daemon_unlock(LOCK_NAME, lock_id)
             self.log.info("lock released: name=%s id=%s", LOCK_NAME, lock_id)
-            return result
 
     def translate(self, name=None, size=None, fmt=True, shared=False):
         data = []

--- a/opensvc/drivers/pool/freenas.py
+++ b/opensvc/drivers/pool/freenas.py
@@ -31,15 +31,13 @@ class Pool(BasePool):
 
     def delete_disk(self, name=None, disk_id=None):
         lock_id = None
-        result = {}
         try:
             lock_id = self.node._daemon_lock(LOCK_NAME, timeout=LOCK_TIMEOUT, on_error="raise")
             self.log.info("lock acquired: name=%s id=%s", LOCK_NAME, lock_id)
-            result = self.array.del_iscsi_zvol(name=name, volume=self.diskgroup)
+            return self.array.del_iscsi_zvol(name=name, volume=self.diskgroup)
         finally:
             self.node._daemon_unlock(LOCK_NAME, lock_id)
             self.log.info("lock released: name=%s id=%s", LOCK_NAME, lock_id)
-            return result
 
     def create_disk(self, name, size, nodes=None):
         mappings = self.get_mappings(nodes)

--- a/opensvc/drivers/resource/container/docker/__init__.py
+++ b/opensvc/drivers/resource/container/docker/__init__.py
@@ -45,6 +45,12 @@ KEYWORDS = [
         "text": "Run container in background. Set to ``false`` only for init containers, alongside :kw:`start_timeout` and the :c-tag:`nostatus` tag.",
     },
     {
+        "keyword": "read_only",
+        "at": True,
+        "convert": "tristate",
+        "text": "Mount the container's root filesystem as read only.",
+    },
+    {
         "keyword": "entrypoint",
         "at": True,
         "text": "The script or binary executed in the container. Args must be set in :kw:`command`.",
@@ -333,6 +339,7 @@ class ContainerDocker(BaseContainer):
                  run_args=None,
                  detach=True,
                  entrypoint=None,
+                 read_only=None,
                  rm=None,
                  user=None,
                  netns=None,
@@ -366,6 +373,7 @@ class ContainerDocker(BaseContainer):
         self.run_command = run_command
         self.run_args = run_args
         self.detach = detach
+        self.read_only = read_only
         self.entrypoint = entrypoint
         self.rm = rm
         self.user = user
@@ -864,6 +872,11 @@ class ContainerDocker(BaseContainer):
             args = drop_option("--privileged", args, drop_value=False)
         if self.privileged:
             args += ["--privileged"]
+
+        if self.read_only is not None:
+            args = drop_option("--read-only", args, drop_value=False)
+        if self.read_only:
+            args += ["--read-only"]
 
         if self.interactive is not None:
             args = drop_option("--interactive", args, drop_value=False)

--- a/opensvc/drivers/resource/task/__init__.py
+++ b/opensvc/drivers/resource/task/__init__.py
@@ -357,7 +357,7 @@ class BaseTask(Resource):
             return core.status.UP
         elif self.checker == "last_run_warn":
             ret = self.read_last_run_retcode()
-            if ret is not None:
+            if ret is not None and ret != 0:
                 self.status_log("last run exitcode: %d" % ret, "warn")
         return core.status.NA
 


### PR DESCRIPTION
If not set, keep --read-only if set in run_args.
If false, drop --read-only from run_args.
If true, set --read-only on run.

For now default to "not set" for backward.