### PR TITLE
[driver.pool.freenas] Fix missed exception during provision -> create

### DIFF
--- a/opensvc/drivers/pool/freenas.py
+++ b/opensvc/drivers/pool/freenas.py
@@ -8,6 +8,7 @@ from core.pool import BasePool
 LOCK_NAME = "freenas_update_disk"
 LOCK_TIMEOUT = 120
 
+
 class Pool(BasePool):
     type = "freenas"
     capabilities = ["roo", "rwo", "rox", "rwx", "shared", "blk", "iscsi"]
@@ -45,21 +46,19 @@ class Pool(BasePool):
         if not mappings:
             raise ex.Error("refuse to create a disk with no mappings")
         lock_id = None
-        result = {}
         try:
             lock_id = self.node._daemon_lock(LOCK_NAME, timeout=LOCK_TIMEOUT, on_error="raise")
             self.log.info("lock acquired: name=%s id=%s", LOCK_NAME, lock_id)
-            result = self.array.add_iscsi_zvol(name=name, size=size,
-                                               volume=self.diskgroup,
-                                               mappings=mappings,
-                                               insecure_tpc=self.insecure_tpc,
-                                               compression=self.compression,
-                                               sparse=self.sparse,
-                                               blocksize=self.blocksize)
+            return self.array.add_iscsi_zvol(name=name, size=size,
+                                             volume=self.diskgroup,
+                                             mappings=mappings,
+                                             insecure_tpc=self.insecure_tpc,
+                                             compression=self.compression,
+                                             sparse=self.sparse,
+                                             blocksize=self.blocksize)
         finally:
             self.node._daemon_unlock(LOCK_NAME, lock_id)
             self.log.info("lock released: name=%s id=%s", LOCK_NAME, lock_id)
-            return result
 
     def translate(self, name=None, size=None, fmt=True, shared=False):
         data = []

--- a/opensvc/drivers/pool/freenas.py
+++ b/opensvc/drivers/pool/freenas.py
@@ -31,15 +31,13 @@ class Pool(BasePool):
 
     def delete_disk(self, name=None, disk_id=None):
         lock_id = None
-        result = {}
         try:
             lock_id = self.node._daemon_lock(LOCK_NAME, timeout=LOCK_TIMEOUT, on_error="raise")
             self.log.info("lock acquired: name=%s id=%s", LOCK_NAME, lock_id)
-            result = self.array.del_iscsi_zvol(name=name, volume=self.diskgroup)
+            return self.array.del_iscsi_zvol(name=name, volume=self.diskgroup)
         finally:
             self.node._daemon_unlock(LOCK_NAME, lock_id)
             self.log.info("lock released: name=%s id=%s", LOCK_NAME, lock_id)
-            return result
 
     def create_disk(self, name, size, nodes=None):
         mappings = self.get_mappings(nodes)


### PR DESCRIPTION
…_disk -> add_iscsi_zvol

With previous code, the raised exception from add_iscsi_zvol was dropped because of the return statement into the finally block

This improves log and don't anymore return {} when add_iscsi_zvol raises

Previous logs:
# om vol/data provision --local --disable-rollback --leader
@ n:node1 o:vol/data r:disk#1 sc:n
mappings for nodes node1,node2: iqn....
lock acquired: name=freenas_update_disk id=b1189938-05f4-4c4e-ae21-b63ed41b80a0
lock released: name=freenas_update_disk id=b1189938-05f4-4c4e-ae21-b63ed41b80a0
E invalid create disk result: {}

New logs:
# om vol/data provision --local --disable-rollback --leader
@ n:node1 o:vol/data r:disk#1 sc:n
mappings for nodes node1,node2: iqn....
lock acquired: name=freenas_update_disk id=d56525c1-2916-40d0-a25e-dfc6ffb938cb
lock released: name=freenas_update_disk id=d56525c1-2916-40d0-a25e-dfc6ffb938cb
E POST http://freenas-addr/api/v2.0/pool/dataset/ {"name": "tank/data.root.vol.clusterxx", "type": "VOLUME", "volsize": 134217728, "sparse": true, "deduplication": "OFF"} => 422: {
"message": "Failed to create dataset: dataset already exists",
"errno": 14
}