### PR TITLE
object_status running tasks infos

### DIFF
--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -3788,9 +3788,11 @@ class Svc(PgMixin, BaseSvc):
         import utilities.runfiles
         for rid in rids:
             d = os.path.join(self.var_d, rid, "run")
-            if utilities.runfiles.has_running(d):
-                running.append(rid)
-        return [rid for rid in running if rid]
+            task_infos = utilities.runfiles.has_running(d)
+            for info in task_infos:
+                info["rid"] = rid
+                running.append(info)
+        return [info for info in running if info]
 
     def _get_running(self, lockfile):
         try:

--- a/opensvc/utilities/runfiles/__init__.py
+++ b/opensvc/utilities/runfiles/__init__.py
@@ -2,10 +2,19 @@ import os
 
 def has_running(run_dir, log=None, cleanup=False):
     try:
-        if any(is_valid(os.path.join(run_dir, f), log=log, cleanup=cleanup) for f in os.listdir(run_dir)):
-            return True
+        return [info for info in (is_valid(os.path.join(run_dir, f), log=log, cleanup=cleanup) for f in os.listdir(run_dir)) if info]
     except FileNotFoundError:
-        return False
+        return []
+
+def get_sid(run_file):
+    try:
+        with open(run_file, 'r') as f:
+            sid = f.read().strip()
+            if sid:
+                return sid
+            return "unknown"
+    except FileNotFoundError:
+        return "unknown"
 
 def is_valid(run_file, log=None, cleanup=False):
     pid = os.path.basename(run_file)
@@ -24,7 +33,7 @@ def is_valid(run_file, log=None, cleanup=False):
                 log.warn(e)
 
     if str(os.getpid()) == pid:
-        return True
+        return { "pid": int(pid), "session_id": get_sid(run_file) }
 
     try:
         run_file_mtime = os.path.getmtime(run_file)
@@ -38,7 +47,7 @@ def is_valid(run_file, log=None, cleanup=False):
         return False
 
     if proc_pid_mtime <= run_file_mtime:
-        return True
+        return { "pid": int(pid), "session_id": get_sid(run_file) }
 
     do_cleanup("proc %s is not the one that created %s" % (pid, run_file))
     return False

--- a/opensvc/utilities/runfiles/__init__.py
+++ b/opensvc/utilities/runfiles/__init__.py
@@ -1,4 +1,5 @@
 import os
+from env import Env
 
 def has_running(run_dir, log=None, cleanup=False):
     try:
@@ -33,7 +34,7 @@ def is_valid(run_file, log=None, cleanup=False):
                 log.warn(e)
 
     if str(os.getpid()) == pid:
-        return { "pid": int(pid), "session_id": get_sid(run_file) }
+        return { "pid": int(pid), "session_id": Env.session_uuid }
 
     try:
         run_file_mtime = os.path.getmtime(run_file)


### PR DESCRIPTION
* /object_status gives `nodes.<node>.status.running` list of dict in order to better follow async tasks
  * rid
  * sid
  * pid 
```
POST /object_action {"path":"svc1", "action": "run", "sync": false, "options": {"rid": "task#test"}}
{
  "status": 0,
  "data": {
    "pid": 937885,
    "session_id": "e1559261-64eb-48c3-bee4-3086ca6d493e"
  },
  "info": "started svc1 action run --rid=task#test --local"
}
```
```
GET /object_status?path=svc1
.nodes.$HOST.status:
{
  "task#test": {
    "status": "n/a",
    "type": "task.host",
    "label": "task.host",
    "info": {
      "last_run_exitcode": 10,
      "last_run_at": "2025-06-29T22:20:26.042890+02:00",
      "last_run_session_id": "5ca6ff96-c5b8-49e5-9e59-040eb72cca99"
    }
  },
  "running": [
    {
      "pid": 937885,
      "session_id": "e1559261-64eb-48c3-bee4-3086ca6d493e",
      "rid": "task#test"
    }
  ]}
````