### PR TITLE
Force ip6 neighbour announcement in ip.netns if a gateway is configured

### DIFF
--- a/opensvc/drivers/resource/ip/netns/__init__.py
+++ b/opensvc/drivers/resource/ip/netns/__init__.py
@@ -375,6 +375,11 @@ class IpNetns(IpHost):
             cmd = [Env.syspaths.nsenter, "--net="+self.netns] + Env.python_cmd + [os.path.join(Env.paths.pathlib, "utilities", "arp.py"), self.final_guest_dev, self.addr]
             self.log.info(" ".join(cmd))
             out, err, ret = justcall(cmd)
+        elif self.gateway:
+            # make this ip6 pingable asap by forcing a immediate Neighbour Announcement
+            cmd = [Env.syspaths.nsenter, "--net="+self.netns, "ping6", "-c", "1", "-w", "1", "-W", "1", self.gateway]
+            self.log.info(" ".join(cmd))
+            out, err, ret = justcall(cmd)
 
         return 0, "", ""
 
@@ -627,6 +632,12 @@ class IpNetns(IpHost):
             cmd = [Env.syspaths.nsenter, "--net="+self.netns] + Env.python_cmd + [os.path.join(Env.paths.pathlib, "utilities", "arp.py"), self.final_guest_dev, self.addr]
             self.log.info(" ".join(cmd))
             out, err, ret = justcall(cmd)
+        elif self.gateway:
+            # make this ip6 pingable asap by forcing a immediate Neighbour Announcement
+            cmd = [Env.syspaths.nsenter, "--net="+self.netns, "ping6", "-c", "1", "-w", "1", "-W", "1", self.gateway]
+            self.log.info(" ".join(cmd))
+            out, err, ret = justcall(cmd)
+
 
     def get_nspid(self):
         if self.container.type in ("container.docker", "container.podman"):


### PR DESCRIPTION
Ping the gateway once to speed up the ip discovery. Without this we have observed random delays up to 1min between up and ping alive from a distant pinger.