### PR TITLE
app automatic restart only if app has not been previously stopped using scoped call

### DIFF
--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -3932,7 +3932,7 @@ class Svc(PgMixin, BaseSvc):
                 if resource.monitor:
                     _data["monitor"] = resource.monitor
                 if resource.nb_restart:
-                    _data["restart"] = resource.nb_restart
+                    _data["restart"] = 0 if resource.stopped() else resource.nb_restart
                 if len(log) > 0:
                     _data["log"] = log
                 if len(info) > 0:

--- a/opensvc/core/resource.py
+++ b/opensvc/core/resource.py
@@ -152,6 +152,39 @@ class Resource(object):
             os.makedirs(var_d)
         return var_d
 
+    @lazy
+    def stopped_flag(self):
+        """ 
+        transcient stopped state file path
+        """
+        return os.path.join(self.var_d, "stopped")
+
+    def stopped(self):
+        """
+        Return True if the resource has been stopped.
+        """
+        return os.path.exists(self.stopped_flag)
+
+    def stopped_info(self):
+        """
+        status info for the stopped state
+        """
+        if self.stopped():
+            self.log.debug("resource %s is stopped", self.rid)
+            self.status_log("stopped", "info")
+
+    def set_stopped(self, stopped=True):
+        """
+        Set the stopped state file of the resource.
+        """
+        try:
+            if stopped:
+                return open(self.stopped_flag, "w").close()
+            if self.stopped():
+                return os.unlink(self.stopped_flag)
+        except:
+            pass
+
     def set_logger(self, log):
         """
         Set the <log> logger as the resource logger, in place of the default
@@ -926,8 +959,9 @@ class Resource(object):
     def boot(self):
         """
         Clean up actions to do on node boot before the daemon starts.
+        Remove transcient files, reset the stopped state.
         """
-        pass
+        self.set_stopped(False)
 
     def shutdown(self):
         """

--- a/opensvc/daemon/monitor.py
+++ b/opensvc/daemon/monitor.py
@@ -1521,9 +1521,12 @@ class Monitor(shared.OsvcThread, MonitorObjectOrchestratorManualMixin):
                 return False
             if smon.local_expect != "started":
                 return False
+            res = svc.get_resource(rid, with_encap=True)
             try:
-                nb_restart = svc.get_resource(rid, with_encap=True).nb_restart
+                nb_restart = res.nb_restart
             except AttributeError:
+                nb_restart = 0
+            if res.stopped():
                 nb_restart = 0
             retries = self.get_smon_retries(svc.path, rid)
 
@@ -1582,13 +1585,16 @@ class Monitor(shared.OsvcThread, MonitorObjectOrchestratorManualMixin):
         def stdby_resource(svc, rid, resource):
             if resource.get("standby") is not True:
                 return False
+            res = svc.get_resource(rid, with_encap=True)
             try:
-                nb_restart = svc.get_resource(rid, with_encap=True).nb_restart
+                nb_restart = res.nb_restart
                 if nb_restart < self.default_stdby_nb_restart:
                     nb_restart = self.default_stdby_nb_restart
             except AttributeError:
                 nb_restart = self.default_stdby_nb_restart
 
+            if res.stopped():
+                nb_restart = 0
             retries = self.get_smon_retries(svc.path, rid)
             if retries > nb_restart:
                 return False

--- a/opensvc/drivers/resource/app/__init__.py
+++ b/opensvc/drivers/resource/app/__init__.py
@@ -353,6 +353,7 @@ class App(Resource):
             self.status_log(str(exc), "warn")
             raise StatusNA
         ret = self.run("status", cmd, dedicated_log=False)
+        self.stopped_info() # status_log info stopped state
         return ret
 
     def _info(self):
@@ -429,6 +430,7 @@ class App(Resource):
         Start the resource.
         """
         self.create_pg()
+        self.set_stopped(False)
 
         try:
             cmd = self.get_cmd("start")
@@ -476,6 +478,12 @@ class App(Resource):
             if "does not exist" in str(exc):
                 return
             raise
+
+        # avoid automatic restart if stop on scoped resources
+        if self.svc.command_is_scoped() and (self.nb_restart > 0 or self.is_standby):
+            self.set_stopped(True)
+        else:
+            self.set_stopped(False)
 
         status = self.status()
         if status == core.status.DOWN:


### PR DESCRIPTION
Proposal to have a "systemd like" `restart` parameter behavior (automatic restart occurs only if app has not been specifically stopped):
* when app is stopped using scoped stop (`om svc stop --rid app#app`) and has restart:
  * create local node transcient flag file "stopped" for the resource
* at monitor, set nb_restart = 0 if app is "stopped" (flag present)
* clear "stopped" transcient files at boot or start of the resource
* in status display `info: stopped` if flag present

```
svc1                             up
`- instances
   `- centos8                    up         idle, started
      |- app#app1       ...../.1 up         forking: app
      |- app#app2       ...../S. stdby up   forking: app2
```
after `om svc1 stop --rid app#app1`
```
svc1                             down
`- instances
   `- centos8                    stdby up   idle, started
      |- app#app1       ...../.. down       forking: app
      |                                     info: stopped
      |- app#app2       ...../S. stdby up   forking: app2
```

