### PR TITLE
bugfix: race condition during app status lock/unlock is causing app action failure

### DIFF
--- a/opensvc/drivers/resource/app/__init__.py
+++ b/opensvc/drivers/resource/app/__init__.py
@@ -591,7 +591,7 @@ class App(Resource):
         and stop actions.
         Or acquire-release the app resource lock and run status.
         """
-        self.lock(action)
+        self.lock(action, timeout=1, delay=0.2)
         if action == "status":
             self.unlock()
         try:


### PR DESCRIPTION
as scheduled `om svc status` is not locking svc but app action status is locking the resource:
if an app action is exactly launched between app lock/unlock by status it will fail with:
```
om svc1 start --rid app#app1
@ n:centos8 o:svc1 sc:n
@ n:centos8 o:svc1 r:app#app1 sc:n
E timed out waiting for lock (timeout 0, delay 1, action start, lockfile /var/lib/opensvc/svc/svc1/app#app1/lock): lock /var/lib/opensvc/svc/svc1/app#app1/lock holder pid 312790, holder intent 'status'
```
as the app lock is with timeout 0.

the lock/unlock of app status is fast as nothing done between lock and unlock, adding timeout 1s should be enough to ensure the unlock by status is done, not making service action failing. (cannot reproduce the issue with the timeout)

