### PR TITLE
Fix a misinterpreted LastSyncTime=NA in the array.hp3par driver

### DIFF
--- a/opensvc/drivers/array/hp3par.py
+++ b/opensvc/drivers/array/hp3par.py
@@ -355,7 +355,10 @@ class Hp3par(object):
             vv_data = {}
             for a, b in zip(cols_vv, v):
                 vv_data[a] = b
-            vv_data['LastSyncTime'] = self.s_to_datetime(vv_data['LastSyncTime'])
+            try:
+                vv_data['LastSyncTime'] = self.s_to_datetime(vv_data['LastSyncTime'])
+            except Exception:
+                vv_data['LastSyncTime'] = None
             vv_l.append(vv_data)
         data = {'rcg': rcg_data, 'vv': vv_l}
         return data

--- a/opensvc/drivers/resource/sync/hp3par/__init__.py
+++ b/opensvc/drivers/resource/sync/hp3par/__init__.py
@@ -319,7 +319,7 @@ class SyncHp3par(Sync):
             if vv['SyncStatus'] != 'Synced':
                 self.status_log("vv %s SyncStatus is not Synced (%s)"%(vv['LocalVV'], vv['SyncStatus']))
                 r = core.status.WARN
-            if vv['LastSyncTime'] < elapsed:
+            if vv.get('LastSyncTime') and vv['LastSyncTime'] < elapsed:
                 self.status_log("vv %s last sync too old (%s)"%(vv['LocalVV'], vv['LastSyncTime'].strftime("%Y-%m-%d %H:%M")))
                 r = core.status.WARN
 


### PR DESCRIPTION
Parse it as a None.

Example:

	|- sync#1           ...O./.. undef      hp3par async RCG.DOPENSVC
	|                                       error: time data '' does not match format '%Y-%m-%d %H:%M:%S'