### PR TITLE
limit backlogs result since/until timestamp

### DIFF
--- a/opensvc/commands/mgr/parser.py
+++ b/opensvc/commands/mgr/parser.py
@@ -271,6 +271,11 @@ OPT = Storage({
         action="store", dest="sid",
         help="Session id to filter "
              "from the log file tail. Default is None."),
+    "since": Option(
+        "--since", default=None,
+        action="store", dest="since",
+        help="Limit result to log since timestamp "
+             "from the log file tail. Default is None."),
     "slave": Option(
         "--slave", default=None, action="store", dest="slave",
         help="Limit the action to the service resources in the specified, comma-"
@@ -316,6 +321,11 @@ OPT = Storage({
         action="store_true", dest="unprovision",
         help="Unprovision the service resources before config files file deletion. "
              "Defaults to False."),
+    "until": Option(
+        "--until", default=None,
+        action="store", dest="until",
+        help="Limit result to log until timestamp "
+             "from the log file tail. Default is None."),
     "value": Option(
         "--value", default=None,
         action="store", dest="value",
@@ -406,6 +416,8 @@ ACTIONS = {
                 OPT.follow,
                 OPT.nopager,
                 OPT.sid,
+                OPT.since,
+                OPT.until,
             ]
         },
         "ls": {

--- a/opensvc/commands/node/parser.py
+++ b/opensvc/commands/node/parser.py
@@ -271,6 +271,11 @@ OPT = Storage({
         "--save", default=False,
         action="store_true", dest="save",
         help="Save the collector cli settings to the file specified by --config or ~/.opensvc-cli by default."),
+    "since": Option(
+        "--since", default=None,
+        action="store", dest="since",
+        help="Limit result to log since timestamp "
+             "from the log file tail. Default is None."),
     "stats_dir": Option(
         "--stats-dir", default=None,
         action="store", dest="stats_dir",
@@ -311,6 +316,11 @@ OPT = Storage({
         action="store", dest="time",
         help="Number of seconds to wait for an async action to "
              "finish. The default is 5 minutes."),
+    "until": Option(
+        "--until", default=None,
+        action="store", dest="until",
+        help="Limit result to log until timestamp "
+             "from the log file tail. Default is None."),
     "user": Option(
         "--user", default=None, action="store", dest="user",
         help="Authenticate with the collector using the "
@@ -385,6 +395,8 @@ ACTIONS = {
             "options": [
                 OPT.backlog,
                 OPT.follow,
+                OPT.since,
+                OPT.until,
             ]
         },
         "ping": {

--- a/opensvc/core/node/node.py
+++ b/opensvc/core/node/node.py
@@ -3524,8 +3524,8 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
         nodes = self.nodes_selector(node)
         auto = sorted(nodes, reverse=True)
         self._backlogs(server=self.options.server, node=node,
-                       backlog=self.options.backlog,
-                       debug=self.options.debug,
+                       backlog=self.options.backlog, since=self.options.since,
+                       until=self.options.until, debug=self.options.debug,
                        auto=auto)
         if not self.options.follow:
             return
@@ -3539,10 +3539,10 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
             if exc.errno == EPIPE:
                 return
 
-    def _backlogs(self, server=None, node=None, backlog=None, debug=False, auto=None):
+    def _backlogs(self, server=None, node=None, backlog=None, since=None, until=None, debug=False, auto=None):
         from utilities.render.color import colorize_log_line
         lines = []
-        for line in self.daemon_backlogs(server, node, backlog, debug):
+        for line in self.daemon_backlogs(server, node, backlog, since, until, debug):
             line = colorize_log_line(line, auto=auto)
             if line:
                 try:
@@ -4926,11 +4926,13 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
             self.unset_lazy("cluster_names")
             self.unset_lazy("cluster_key")
 
-    def daemon_backlogs(self, server=None, node=None, backlog=None, debug=False):
+    def daemon_backlogs(self, server=None, node=None, backlog=None, since=None, until=None, debug=False):
         req = {
             "action": "node_backlogs",
             "options": {
                 "backlog": backlog,
+                "since": since,
+                "until": until,
                 "debug": debug,
             }
         }

--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -1965,13 +1965,15 @@ class BaseSvc(Crypt, ExtConfigMixin):
     # daemon communications
     #
     #########################################################################
-    def daemon_backlogs(self, server=None, node=None, backlog=None, sid=None, debug=False):
+    def daemon_backlogs(self, server=None, node=None, backlog=None, sid=None, since=None, until=None, debug=False):
         req = {
             "action": "object_backlogs",
             "options": {
                 "path": self.path,
                 "backlog": backlog,
                 "sid": sid,
+                "since": since,
+                "until": until,
                 "debug": debug,
             }
         }
@@ -2252,8 +2254,8 @@ class BaseSvc(Crypt, ExtConfigMixin):
         auto = sorted(nodes, reverse=True)
         self._backlogs(server=self.options.server, node=node,
                        backlog=self.options.backlog, sid=self.options.sid,
-                       debug=self.options.debug,
-                       auto=auto)
+                       since=self.options.since, until=self.options.until,
+                       debug=self.options.debug, auto=auto)
         if not self.options.follow:
             return
         try:
@@ -2266,10 +2268,10 @@ class BaseSvc(Crypt, ExtConfigMixin):
                 # broken pipe
                 return
 
-    def _backlogs(self, server=None, node=None, backlog=None, sid=None, debug=False, auto=None):
+    def _backlogs(self, server=None, node=None, backlog=None, sid=None, since=None, until=None, debug=False, auto=None):
         from utilities.render.color import colorize_log_line
         lines = []
-        for line in self.daemon_backlogs(server, node, backlog, sid, debug):
+        for line in self.daemon_backlogs(server, node, backlog, sid, since, until, debug):
             try:
                 line = colorize_log_line(line, auto=auto)
             except Exception as exc:

--- a/opensvc/daemon/handlers/node/backlogs/get.py
+++ b/opensvc/daemon/handlers/node/backlogs/get.py
@@ -19,11 +19,25 @@ class Handler(daemon.handler.BaseHandler):
             "default": "10k",
             "desc": "The per-instance backlog size.",
         },
+        {
+            "name": "since",
+            "required": False,
+            "format": "string",
+            "default": None,
+            "desc": "The timestamp to limit result since (timestamp or datetime)",
+        },
+        {
+            "name": "until",
+            "required": False,
+            "format": "string",
+            "default": None,
+            "desc": "The timestamp to limit result until (timestamp or datetime)",
+        },
     ]
 
     def action(self, nodename, thr=None, stream_id=None, **kwargs):
         options = self.parse_options(kwargs)
         logfile = os.path.join(Env.paths.pathlog, "node.log")
         ofile = thr._action_logs_open(logfile, options.backlog, "node")
-        return thr.read_file_lines(ofile)
+        return thr.read_file_lines(ofile, since=options.since, until=options.until)
 

--- a/opensvc/daemon/handlers/object/backlogs/get.py
+++ b/opensvc/daemon/handlers/object/backlogs/get.py
@@ -33,6 +33,20 @@ class Handler(daemon.handler.BaseHandler):
             "default": None,
             "desc": "The session id to filter from the log file tail.",
         },
+        {
+            "name": "since",
+            "required": False,
+            "format": "string",
+            "default": None,
+            "desc": "The timestamp to limit result since (timestamp or datetime)",
+        },
+        {
+            "name": "until",
+            "required": False,
+            "format": "string",
+            "default": None,
+            "desc": "The timestamp to limit result until (timestamp or datetime)",
+        },
     ]
     access = {
         "roles": ["guest"],
@@ -46,5 +60,5 @@ class Handler(daemon.handler.BaseHandler):
             raise ex.HTTP(404, "%s not found" % options.path)
         logfile = os.path.join(svc.log_d, svc.name+".log")
         ofile = thr._action_logs_open(logfile, options.backlog, svc.path)
-        return thr.read_file_lines(ofile, options.sid)
+        return thr.read_file_lines(ofile, sid=options.sid, since=options.since, until=options.until)
 

--- a/opensvc/daemon/listener.py
+++ b/opensvc/daemon/listener.py
@@ -2038,9 +2038,38 @@ class ClientHandler(shared.OsvcThread):
             line = ofile.readline()
         return ofile
 
-    def read_file_lines(self, ofile, sid=None):
+    def read_file_lines(self, ofile, sid=None, since=None, until=None):
         data = []
         buff = ""
+
+        def convert_dt(ts_dt):
+            # convert dt to timestamp float
+            # dt can be timestamp, date time, or iso string
+            if not ts_dt:
+                return None
+            try:
+                return float(ts_dt)
+            except ValueError:
+                pass
+            ts_dt = str(ts_dt)
+            dt_str = ts_dt + "0000-01-01 00:00:00,000000"[len(ts_dt):]
+            try:
+                dt = datetime.datetime.strptime(dt_str, "%Y-%m-%d %H:%M:%S,%f")
+                return time.mktime(dt.timetuple()) + dt.microsecond / 1000000
+            except ValueError:
+                pass
+            try: # iso datetime (python3.7+ only)
+                dt = datetime.datetime.fromisoformat(ts_dt)
+                return dt.timestamp()
+            except AttributeError:
+                self.log.warning("invalid datetime format '%s' (iso not supported)", ts_dt)
+            except ValueError:
+                self.log.warning("invalid datetime format '%s'", ts_dt)
+                return None
+
+        since = convert_dt(since)
+        until = convert_dt(until)
+
         def parse(_buff):
             head, message = _buff.split(" | ", 1)
             date_s, time_s, lvl, meta = head.split(None, 3)
@@ -2066,6 +2095,12 @@ class ClientHandler(shared.OsvcThread):
                     # new msg, push pending buff
                     try:
                         parse_data = parse(buff)
+                        if since and parse_data["t"] < since:
+                            buff = line
+                            continue
+                        if until and parse_data["t"] > until:
+                            buff = ""
+                            break
                         if sid:
                             if parse_data["x"]["sid"] == sid:
                                 data.append(parse_data)
@@ -2080,6 +2115,8 @@ class ClientHandler(shared.OsvcThread):
             # EOF, push pending buff
             try:
                 parse_data = parse(buff)
+                if since and parse_data["t"] < since:
+                    return data
                 if sid and parse_data["x"]["sid"] != sid:
                     return data
                 data.append(parse_data)


### PR DESCRIPTION
Add standard `since`/`until` parameters to /object_backlogs and /node_backlogs routes to limit result to lines produced during timestamp interval.
* allow async log follow using API polling backlogs endpoint without getting full log each time.
* `since`/`until` parameters  can be a timestamp value, date time format, or iso datetime (python 3.7+ required)
* date time string can be truncated and will be padded
  * eg: "YYYY-MM-DD" => "YYYY-MM-DD 00:00:00,000000"
  * eg: "YYYY-MM-DD HH => "YYYY-MM-DD HH:00:00:00,000000"
* add `--since`/`--until` parameter to om svc logs
* add --since`/`--until` parameter to om node logs
