### PR TITLE
Add a configurable delay after a container.kvm is considered operational

### DIFF
--- a/opensvc/core/network.py
+++ b/opensvc/core/network.py
@@ -240,7 +240,13 @@ class NetworksMixin(object):
             if addr in ("127.0.0.1", "127.0.1.1", "::1") or addr.startswith("fe80:"):
                 continue
             return addr
-        raise ex.Error("node %s has no %s address" % (nodename, af))
+        if af == socket.AF_INET:
+            afs = "ipv4"
+        elif af == socket.AF_INET6:
+            afs = "ipv6"
+        else:
+            afs = "%s" % af
+        raise ex.Error("node %s has no %s address" % (nodename, afs))
 
     def routes(self, name, config=None):
         routes = []

--- a/opensvc/drivers/array/symmetrix.py
+++ b/opensvc/drivers/array/symmetrix.py
@@ -15,6 +15,7 @@ from utilities.converters import convert_size
 from utilities.optparser import OptParser, Option
 from core.node import Node
 from utilities.proc import justcall, which
+from utilities.lazy import lazy
 
 PROG = "om array"
 OPT = Storage({
@@ -972,6 +973,25 @@ class Vmax(SymMixin):
         else:
             self.aclx = None
 
+    @lazy
+    def get_symcli_version(self):
+        symcli_bin = self.symcli_path + "/symcli"
+        out, err, ret = justcall([symcli_bin, ])
+        if ret != 0:
+            return None
+        import re
+        m = re.search(r"\(SYMCLI\)\sVersion V(\d+)\.(\d+)", out)
+        if m:
+            return int(m.group(1)), int(m.group(2))
+        return None
+
+    def check_symcli_version(self, major, minor):
+        version = self.get_symcli_version
+        if version:
+            v_major, v_minor = version
+            return (v_major > major) or (v_major == major and v_minor > minor)
+        return None
+
     def symaccesscmd(self, cmd, xml=True, log=False):
         self.set_environ()
         cmd = ['/usr/symcli/bin/symaccess'] + cmd
@@ -1218,8 +1238,10 @@ class Vmax(SymMixin):
         self.del_map(dev)
         self.deletepair(dev)
         retry = 5
+        do_free = self.check_symcli_version(9, 1)
         while retry > 0:
-            self.free_tdev(dev)
+            if not do_free:
+                self.free_tdev(dev)
             try:
                 self.del_tdev(dev=dev, **kwargs)
                 break

--- a/opensvc/drivers/resource/container/__init__.py
+++ b/opensvc/drivers/resource/container/__init__.py
@@ -16,6 +16,13 @@ KW_QGA = {
     "at": True,
     "text": "Use vsock or vserial to communicate with the container via the qemu guest agent. This option requires qemu guest agent to be installed in the container.",
 }
+KW_QGA_OPERATIONAL_DELAY = {
+    "keyword": "qga_operational_delay",
+    "convert": "duration",
+    "at": True,
+    "text": "Wait after we successfully tested a pwd in the container, so the os is sufficiently started to accept a encap start.",
+    "default": "10",
+}
 KW_START_TIMEOUT = {   
     "keyword": "start_timeout",
     "convert": "duration",

--- a/opensvc/drivers/resource/container/kvm/__init__.py
+++ b/opensvc/drivers/resource/container/kvm/__init__.py
@@ -1,10 +1,14 @@
 from __future__ import print_function
 
 import os
+import json
+import time
+import base64
+
+from xml.etree.ElementTree import ElementTree, SubElement
 
 import core.exceptions as ex
 import utilities.ping
-
 
 from .. import \
     BaseContainer, \
@@ -20,13 +24,15 @@ from .. import \
     KW_GUESTOS, \
     KW_PROMOTE_RW, \
     KW_SCSIRESERV, \
-    KW_QGA
+    KW_QGA, \
+    KW_QGA_OPERATIONAL_DELAY
 from core.resource import Resource
 from env import Env
 from utilities.cache import cache, clear_cache
 from utilities.lazy import lazy
 from core.objects.svcdict import KEYS
 from utilities.proc import justcall, which
+from utilities.string import bdecode
 
 CAPABILITIES = {
     "partitions": "1.0.1",
@@ -48,6 +54,7 @@ KEYWORDS = [
     KW_PROMOTE_RW,
     KW_SCSIRESERV,
     KW_QGA,
+    KW_QGA_OPERATIONAL_DELAY,
 ]
 
 KEYS.register_driver(
@@ -72,6 +79,7 @@ class ContainerKvm(BaseContainer):
                  snapof=None,
                  virtinst=None,
                  qga=False,
+                 qga_operational_delay=10,
                  **kwargs):
         super(ContainerKvm, self).__init__(type="container.kvm", **kwargs)
         self.refresh_provisioned_on_provision = True
@@ -80,6 +88,7 @@ class ContainerKvm(BaseContainer):
         self.snapof = snapof
         self.virtinst = virtinst or []
         self.qga = qga
+        self.qga_operational_delay = qga_operational_delay
 
     @lazy
     def cf(self):
@@ -128,9 +137,6 @@ class ContainerKvm(BaseContainer):
         return utilities.ping.check_ping(self.addr, timeout=1, count=1)
 
     def qga_exec_status(self, pid):
-        import json
-        import base64
-        from utilities.string import bdecode
         payload = {
             "execute": "guest-exec-status",
             "arguments": {
@@ -147,7 +153,6 @@ class ContainerKvm(BaseContainer):
         return data
 
     def qga_operational(self):
-        import json
         payload = {
             "execute": "guest-exec",
             "arguments": {
@@ -180,9 +185,6 @@ class ContainerKvm(BaseContainer):
 
     def qga_cp(self, src, dst):
         self.log.debug("qga cp: %s to %s", src, dst)
-        import base64
-        import json
-        import time
         payload = {
             "execute":"guest-file-open",
             "arguments":{
@@ -234,8 +236,6 @@ class ContainerKvm(BaseContainer):
         else:
             log = self.log.debug
         log("qga exec: %s", " ".join(cmd))
-        import json
-        import time
         payload = {
             "execute": "guest-exec",
             "arguments": {
@@ -277,7 +277,14 @@ class ContainerKvm(BaseContainer):
         if self.guestos == "windows":
             return True
         if self.qga:
-            return self.qga_operational()
+            v = self.qga_operational()
+            if v:
+                # qga is operational, but we have no generic method to ensure
+                # the os is far enough in the boot for a encap start to succeed
+                # (network, sssd, dockerd, ... may need to be started but we don't
+                # know if they are managed by systemd, openrc, ...)
+                time.sleep(self.qga_operational_delay)
+            return v
         else:
             return BaseContainer.operational(self)
 
@@ -405,7 +412,6 @@ class ContainerKvm(BaseContainer):
         return out.strip()
 
     def unset_partition(self):
-        from xml.etree.ElementTree import ElementTree
         tree = ElementTree()
         try:
             tree.parse(self.cf)
@@ -429,7 +435,6 @@ class ContainerKvm(BaseContainer):
 
     def set_partition(self):
         self.svc.pg.create_pg(self)
-        from xml.etree.ElementTree import ElementTree, SubElement
         tree = ElementTree()
         try:
             tree.parse(self.cf)
@@ -454,7 +459,6 @@ class ContainerKvm(BaseContainer):
     def install_drp_flag(self):
         flag_disk_path = os.path.join(Env.paths.pathvar, 'drp_flag.vdisk')
 
-        from xml.etree.ElementTree import ElementTree, SubElement
         tree = ElementTree()
         try:
             tree.parse(self.cf)
@@ -492,7 +496,6 @@ class ContainerKvm(BaseContainer):
 
     def firmware_files(self):
         l = []
-        from xml.etree.ElementTree import ElementTree
         tree = ElementTree()
         try:
             tree.parse(self.cf)
@@ -508,7 +511,6 @@ class ContainerKvm(BaseContainer):
         return l
 
     def has_efi(self):
-        from xml.etree.ElementTree import ElementTree
         tree = ElementTree()
         try:
             tree.parse(self.cf)
@@ -532,7 +534,6 @@ class ContainerKvm(BaseContainer):
             return []
         data = []
 
-        from xml.etree.ElementTree import ElementTree
         tree = ElementTree()
         try:
             tree.parse(self.cf)


### PR DESCRIPTION
The new qga_operational_delay keyword has a 10s default value.

When the container is operational, the start encap command will follow very soon, and may fail because the operating system is still activating subsystems.

For example we are already aware of sssd and dockerd dependencies in real life situations. But we can not guess all dependencies of a particular service and we don't want to maintain all deps testing involved.