### PR TITLE
Fix a jstat checker stack due to bad decode pattern for² utf-8

### DIFF
--- a/opensvc/drivers/check/jstat/linux.py
+++ b/opensvc/drivers/check/jstat/linux.py
@@ -109,9 +109,14 @@ OPTIONS = [
 
 
 def pid_to_ids(pid):
-    with open("/proc/%d/environ" % pid, 'rb') as fp:
-        buff = fp.read()
     data = Storage()
+
+    try:
+        with open("/proc/%d/environ" % pid) as fp:
+            buff = fp.read()
+    except Exception:
+        # OSError, IOError, FileNotFoundError ...
+        return data
 
     try:
         buff = buff.decode('utf-8')

--- a/opensvc/drivers/check/jstat/linux.py
+++ b/opensvc/drivers/check/jstat/linux.py
@@ -109,9 +109,15 @@ OPTIONS = [
 
 
 def pid_to_ids(pid):
-    with open("/proc/%d/environ" % pid) as fp:
+    with open("/proc/%d/environ" % pid, 'rb') as fp:
         buff = fp.read()
     data = Storage()
+
+    try:
+        buff = buff.decode('utf-8')
+    except UnicodeDecodeError:
+        buff = buff.decode('utf-8', errors='replace')  # or 'ignore'
+
     for line in buff.split('\0'):
         line = line.replace("\n", "")
         try:


### PR DESCRIPTION
Example stack:

	$ om node checks
	Traceback (most recent call last):
	  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
	    return _run_code(code, main_globals, None,
	  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
	    exec(code, run_globals)
	  File "/usr/share/opensvc/opensvc/__main__.py", line 131, in <module>
	    ret = main(sys.argv)
	  File "/usr/share/opensvc/opensvc/__main__.py", line 103, in main
	    ret = main(argv=argv[2:])
	  File "/usr/share/opensvc/opensvc/commands/node/__init__.py", line 65, in main
	    return _main(node, argv=argv)
	  File "/usr/share/opensvc/opensvc/commands/node/__init__.py", line 45, in _main
	    err = node.action(action)
	  File "/usr/share/opensvc/opensvc/core/node/node.py", line 999, in action
	    return self._action(action, options)
	  File "/usr/share/opensvc/opensvc/core/scheduler.py", line 177, in _func
	    ret = func(self, action, options)
	  File "/usr/share/opensvc/opensvc/core/node/node.py", line 1029, in _action
	    ret = getattr(self, action)()
	  File "/usr/share/opensvc/opensvc/core/node/node.py", line 1759, in checks
	    data = drvs.do_checks()
	  File "/usr/share/opensvc/opensvc/drivers/check/__init__.py", line 101, in do_checks
	    _data = chk.do_check()
	  File "/usr/share/opensvc/opensvc/drivers/check/jstat/linux.py", line 28, in do_check
	    ids = pid_to_ids(pid)
	  File "/usr/share/opensvc/opensvc/drivers/check/jstat/linux.py", line 113, in pid_to_ids
	    buff = fp.read()
	  File "/usr/lib/python3.10/codecs.py", line 322, in decode
	    (result, consumed) = self._buffer_decode(data, self.errors, final)
	UnicodeDecodeError: 'utf-8' codec can't decode byte 0x99 in position 149: invalid start byte