### PR TITLE
Use the MemAvailable linux kernel metric instead of computing somethi…

### DIFF
--- a/opensvc/core/node/linux.py
+++ b/opensvc/core/node/linux.py
@@ -62,7 +62,7 @@ class Node(BaseNode):
                     continue
                 raw_data[elem[0].rstrip(":")] = int(elem[1])
         data["mem_total"] = raw_data["MemTotal"] // 1024
-        data["mem_avail"] = 100 * (raw_data["MemFree"] + raw_data["Cached"] + raw_data.get("SwapCached", 0) + raw_data.get("SReclaimable", 0)) // raw_data["MemTotal"]
+        data["mem_avail"] = 100 * raw_data.get("MemAvailable", 0) // raw_data["MemTotal"]
         data["swap_total"] = raw_data["SwapTotal"] // 1024
         try:
             data["swap_avail"] = 100 * raw_data["SwapFree"] // raw_data["SwapTotal"]


### PR DESCRIPTION
…ng alike

Our approximation is not good enough: buffers were not accounted as free for example.