### PR TITLE
[monitor] Improve hb dataset update handling for peer agent reset detection

### DIFF
--- a/opensvc/core/collector/rpc.py
+++ b/opensvc/core/collector/rpc.py
@@ -808,7 +808,7 @@ class CollectorRpc(object):
         return self.proxy.daemon_ping(*args)
 
     def push_status(self, svcname, data, sync=True):
-        if data.get("encap", False):
+        if data.get("encap", False) is True:
             self.log.info("skip push status for encap object %s", svcname)
             return
         try:

--- a/opensvc/daemon/monitor.py
+++ b/opensvc/daemon/monitor.py
@@ -4500,11 +4500,15 @@ class Monitor(shared.OsvcThread, MonitorObjectOrchestratorManualMixin):
                 self.log.debug("no 'gen' in full dataset from %s: drop", nodename)
                 return False
             if peer_gen_merged >= peer_gen_from_message:
-                self.log.debug("already installed or beyond %s gen %d dataset (current gen merged: %s): drop",
-                               nodename,
-                               peer_gen_from_message,
-                               peer_gen_merged)
-                return False
+                updated_at_from_msg = data.get("updated", 0)
+                updated_at_applied = self.nodes_data.get([nodename, "updated"], default=0)
+                if updated_at_from_msg > updated_at_applied:
+                    self.log.debug("detect hb full dataset from restarted node %s (updated: %s->%s, gen: %d->%d)",
+                                   nodename, updated_at_applied, updated_at_from_msg, peer_gen_merged, peer_gen_from_message)
+                else:
+                    self.log.debug("drop already applied hb full dataset from node %s (current gen: %d, msg gen %d)",
+                                   nodename, peer_gen_merged, peer_gen_from_message)
+                    return False
             node_status = data.get("monitor", {}).get("status")
             if node_status in ("init", "maintenance", "upgrade") and self.nodes_data.exists([nodename]):
                 for path, _, idata in self.iter_services_instances(nodenames=[nodename]):


### PR DESCRIPTION
### Changes Introduced
- Enhanced heartbeat (hb) dataset processing by comparing `updated_at` values to better detect newer datasets from peer nodes. Added logging for possible peer agent resets.
- Resolved issue in the collector where "encap" key was mistakenly processed as a slave, leading to the unexpected "skip push status for encap object