### PR TITLE
Add the OPENSVC_RID var to resource trigger processes env

### DIFF
--- a/opensvc/core/resource.py
+++ b/opensvc/core/resource.py
@@ -362,6 +362,11 @@ class Resource(object):
         Executes a resource trigger. Guess if the shell mode is needed from
         the trigger syntax.
         """
+        env = kwargs.get("env")
+        if env is None:
+            env = dict(os.environ)
+        env["OPENSVC_RID"] = self.rid
+        kwargs["env"] = env
         action_triggers(self, trigger, action, **kwargs)
 
     def handle_confirm(self, action):


### PR DESCRIPTION
This var helps to develop generic triggers scripts with behaviour switch on the rid value.

Example:

	$ /opt/opensvc/bin/om testc2 start --local
	...
	@ n:eggplant o:testc2 rs:g2 r:fs#3 sc:n
	  post_start: echo $OPENSVC_RID
	  | fs#3