### PR TITLE
Implement OC3 sysreport

### DIFF
--- a/opensvc/core/node/node.py
+++ b/opensvc/core/node/node.py
@@ -3068,10 +3068,14 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
             request.add_header("Authorization", "Basic %s" % self.collector_basic_node())
 
         if data is not None:
+            if isinstance(data, bytes):
+                raw = data
+            else:
+                raw = json.dumps(data).encode('utf-8')
             try:
-                request.add_data(json.dumps(data).encode('utf-8'))
+                request.add_data(raw)
             except AttributeError:
-                request.data = json.dumps(data).encode('utf-8')
+                request.data = raw
 
         kwargs = {}
         kwargs = self.set_ssl_context(kwargs)

--- a/opensvc/core/oc3path/__init__.py
+++ b/opensvc/core/oc3path/__init__.py
@@ -12,6 +12,7 @@ FEED_INSTANCE_RESINFO = "/api/instance/resource_info"
 FEED_INSTANCE_STATUS = "/api/instance/status"
 
 FEED_NODE_DISK = "/api/node/disk"
+FEED_NODE_SYSREPORT = "/api/node/sysreport"
 FEED_NODE_SYSTEM = "/api/node/system"
 
 FEED_OBJECT_CONFIG = "/api/object/config"

--- a/opensvc/core/sysreport/sysreport.py
+++ b/opensvc/core/sysreport/sysreport.py
@@ -496,8 +496,11 @@ class BaseSysReport(object):
             "Content-Type": "multipart/form-data; boundary=" + boundary,
         }
 
-        status_code, resp = self.node.oc3_request_feed("POST", oc3path.FEED_NODE_SYSREPORT, headers=headers, data=body)
-        self.node.oc3_assert_status_code("POST", oc3path.FEED_NODE_SYSREPORT, status_code, resp, expected=[202])
+        try:
+            status_code, resp = self.node.oc3_request_feed("POST", oc3path.FEED_NODE_SYSREPORT, headers=headers, data=body)
+            self.node.oc3_assert_status_code("POST", oc3path.FEED_NODE_SYSREPORT, status_code, resp, expected=[202])
+        except Exception as exc:
+            raise ex.Error(str(exc))
 
     @staticmethod
     def mangle_sep(fpath):

--- a/opensvc/core/sysreport/sysreport.py
+++ b/opensvc/core/sysreport/sysreport.py
@@ -455,10 +455,49 @@ class BaseSysReport(object):
             tmpf = None
 
         print("sending sysreport")
-        self.node.collector.call(self.send_rpc, tmpf, self.deleted)
+        from utilities.semver import Semver
+        if self.node.oc3_version() >= Semver(3, 0, 1):
+            self._oc3_send(tmpf, self.deleted)
+        else:
+            self.node.collector.call(self.send_rpc, tmpf, self.deleted)
 
         if tmpf is not None:
             os.unlink(tmpf)
+
+    def _oc3_send(self, fpath, deleted):
+        import uuid
+        import core.oc3path as oc3path
+
+        boundary = uuid.uuid4().hex
+        boundary_bytes = boundary.encode('utf-8')
+        parts = []
+
+        if fpath is not None:
+            with open(fpath, 'rb') as f:
+                fdata = f.read()
+            parts.append(
+                b'--' + boundary_bytes + b'\r\n' +
+                b'Content-Disposition: form-data; name="file"; filename="' +
+                os.path.basename(fpath).encode('utf-8') + b'"\r\n' +
+                b'Content-Type: application/octet-stream\r\n\r\n' +
+                fdata + b'\r\n'
+            )
+
+        for d in deleted:
+            parts.append(
+                b'--' + boundary_bytes + b'\r\n' +
+                b'Content-Disposition: form-data; name="deleted"\r\n\r\n' +
+                d.encode('utf-8') + b'\r\n'
+            )
+
+        body = b''.join(parts) + b'--' + boundary_bytes + b'--\r\n'
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "multipart/form-data; boundary=" + boundary,
+        }
+
+        status_code, resp = self.node.oc3_request_feed("POST", oc3path.FEED_NODE_SYSREPORT, headers=headers, data=body)
+        self.node.oc3_assert_status_code("POST", oc3path.FEED_NODE_SYSREPORT, status_code, resp, expected=[202])
 
     @staticmethod
     def mangle_sep(fpath):


### PR DESCRIPTION
Add support for sending sysreport data to OC3 via the new /api/node/sysreport endpoint, using multipart/form-data.