### PR TITLE
Fix a container.docker and a pool status stack on py2.7

### DIFF
--- a/opensvc/core/node/node.py
+++ b/opensvc/core/node/node.py
@@ -5396,7 +5396,14 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
         #   File "/usr/lib64/python3.4/concurrent/futures/thread.py", line 116, in _adjust_thread_count
         #     if len(self._threads) < self._max_workers:
         # TypeError: unorderable types: int() < NoneType()
-        max_workers = min(32, (os.cpu_count() or 1) + 4)
+        try:
+            from os import cpu_count
+        except ImportError:
+            from multiprocessing import cpu_count
+        except ImportError:
+            cpu_count = lambda: 1
+
+        max_workers = min(32, (cpu_count() or 1) + 4)
         with concurrent_futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
             for name in pools:
                 pool = self.get_pool(name)

--- a/opensvc/drivers/resource/container/docker/__init__.py
+++ b/opensvc/drivers/resource/container/docker/__init__.py
@@ -666,7 +666,14 @@ class ContainerDocker(BaseContainer):
         #     if len(self._threads) < self._max_workers:
         # TypeError: unorderable types: int() < NoneType()
         #
-        max_workers = min(32, (os.cpu_count() or 1) + 4)
+        try:
+            from os import cpu_count
+        except ImportError:
+            from multiprocessing import cpu_count
+        except ImportError:
+            cpu_count = lambda: 1
+
+        max_workers = min(32, (cpu_count() or 1) + 4)
         with concurrent_futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
             future = executor.submit(self.vcall, cmd, warn_to_info=True, env=env)
             try:


### PR DESCRIPTION
2.1-1787-g6b3a0aa9d introduced a os.cpu_count() call in the container.docker and pool status code paths, but os.cpu_count() was added to 3.4 and so a Attribute error is raised on py2.7 and py3.[0-3]

Add a fallback mecanism.