### PR TITLE
Replace `LooseVersion` with vendored `Semver` for Python compatibility

### DIFF
--- a/bin/pkg/changelog
+++ b/bin/pkg/changelog
@@ -30,4 +30,5 @@ LAST=$(git describe --abbrev=0 --tags)
 COMMITS=${1:-$LAST..HEAD}
 echo COMMITS=$COMMITS
 
+export PYTHONPATH=$PYTHONPATH:$(dirname $PATH_SCRIPT/../../..)
 $OSVC_PYTHON $PATH_SCRIPT/changelog.py --commits $COMMITS --verbose

--- a/bin/pkg/changelog.py
+++ b/bin/pkg/changelog.py
@@ -2,14 +2,15 @@
 
 from __future__ import print_function
 import argparse
-import sys
 from subprocess import *
-from distutils.version import LooseVersion
+import opensvc
+from utilities.semver import Semver
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-c", "--commits", type=str, default="HEAD", help="commits boundary. ex : 2.0..HEAD ")
 parser.add_argument("-v", "--verbose", action="store_true", help="add long commit id")
 args = parser.parse_args()
+
 
 def get_commits():
     cmd = ["git", "log", '--pretty=format:%h %H %s', args.commits]
@@ -28,13 +29,20 @@ def get_versions(cids):
     versions = list(out.decode().splitlines())
     return versions
 
+def as_semver(v):
+    # 2.1-1881-g078e7d5f8
+    # ->
+    # 2.1.1881-g078e7d5f8
+    s = v.replace("-", ".", 1)
+    return Semver.parse(s)
+
 def main():
     commits = get_commits()
     cids = [c for c in commits]
     versions = get_versions(cids)
     for i, cid in enumerate(cids):
         commits[cid].insert(0, versions[i])
-    for commit in sorted(commits.values(), key=lambda x: LooseVersion(x[0]), reverse=True):
+    for commit in sorted(commits.values(), key=lambda x: as_semver(x[0]), reverse=True):
         if args.verbose:
             print("%-18s %s  %s" % (commit[0], commit[2], commit[3]))
         else:

--- a/opensvc/foreign/looseversion/LICENSE
+++ b/opensvc/foreign/looseversion/LICENSE
@@ -1,0 +1,48 @@
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Python Software Foundation;
+All Rights Reserved" are retained in Python alone or in any derivative version
+prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.

--- a/opensvc/foreign/looseversion/README.md
+++ b/opensvc/foreign/looseversion/README.md
@@ -1,0 +1,2 @@
+# Vendored from https://github.com/effigies/looseversion.git
+# Do not modify unless syncing with upstream.

--- a/opensvc/foreign/looseversion/__init__.py
+++ b/opensvc/foreign/looseversion/__init__.py
@@ -1,0 +1,245 @@
+"""Provides classes to represent module version numbers (one class for
+each style of version numbering).  There are currently two such classes
+implemented: StrictVersion and LooseVersion.
+
+Every version number class implements the following interface:
+  * the 'parse' method takes a string and parses it to some internal
+    representation; if the string is an invalid version number,
+    'parse' raises a ValueError exception
+  * the class constructor takes an optional string argument which,
+    if supplied, is passed to 'parse'
+  * __str__ reconstructs the string that was passed to 'parse' (or
+    an equivalent string -- ie. one that will generate an equivalent
+    version number instance)
+  * __repr__ generates Python code to recreate the version number instance
+  * _cmp compares the current instance with either another instance
+    of the same class or a string (which will be parsed to an instance
+    of the same class, thus must follow the same rules)
+"""
+
+import re
+import sys
+
+# The rules according to Greg Stein:
+# 1) a version number has 1 or more numbers separated by a period or by
+#    sequences of letters. If only periods, then these are compared
+#    left-to-right to determine an ordering.
+# 2) sequences of letters are part of the tuple for comparison and are
+#    compared lexicographically
+# 3) recognize the numeric components may have leading zeroes
+#
+# The LooseVersion class below implements these rules: a version number
+# string is split up into a tuple of integer and string components, and
+# comparison is a simple tuple comparison.  This means that version
+# numbers behave in a predictable and obvious way, but a way that might
+# not necessarily be how people *want* version numbers to behave.  There
+# wouldn't be a problem if people could stick to purely numeric version
+# numbers: just split on period and compare the numbers as tuples.
+# However, people insist on putting letters into their version numbers;
+# the most common purpose seems to be:
+#   - indicating a "pre-release" version
+#     ('alpha', 'beta', 'a', 'b', 'pre', 'p')
+#   - indicating a post-release patch ('p', 'pl', 'patch')
+# but of course this can't cover all version number schemes, and there's
+# no way to know what a programmer means without asking him.
+#
+# The problem is what to do with letters (and other non-numeric
+# characters) in a version number.  The current implementation does the
+# obvious and predictable thing: keep them as strings and compare
+# lexically within a tuple comparison.  This has the desired effect if
+# an appended letter sequence implies something "post-release":
+# eg. "0.99" < "0.99pl14" < "1.0", and "5.001" < "5.001m" < "5.002".
+#
+# However, if letters in a version number imply a pre-release version,
+# the "obvious" thing isn't correct.  Eg. you would expect that
+# "1.5.1" < "1.5.2a2" < "1.5.2", but under the tuple/lexical comparison
+# implemented here, this just isn't so.
+#
+# Two possible solutions come to mind.  The first is to tie the
+# comparison algorithm to a particular set of semantic rules, as has
+# been done in the StrictVersion class above.  This works great as long
+# as everyone can go along with bondage and discipline.  Hopefully a
+# (large) subset of Python module programmers will agree that the
+# particular flavour of bondage and discipline provided by StrictVersion
+# provides enough benefit to be worth using, and will submit their
+# version numbering scheme to its domination.  The free-thinking
+# anarchists in the lot will never give in, though, and something needs
+# to be done to accommodate them.
+#
+# Perhaps a "moderately strict" version class could be implemented that
+# lets almost anything slide (syntactically), and makes some heuristic
+# assumptions about non-digits in version number strings.  This could
+# sink into special-case-hell, though; if I was as talented and
+# idiosyncratic as Larry Wall, I'd go ahead and implement a class that
+# somehow knows that "1.2.1" < "1.2.2a2" < "1.2.2" < "1.2.2pl3", and is
+# just as happy dealing with things like "2g6" and "1.13++".  I don't
+# think I'm smart enough to do it right though.
+#
+# In any case, I've coded the test suite for this module (see
+# ../test/test_version.py) specifically to fail on things like comparing
+# "1.2a2" and "1.2".  That's not because the *code* is doing anything
+# wrong, it's because the simple, obvious design doesn't match my
+# complicated, hairy expectations for real-world version numbers.  It
+# would be a snap to fix the test suite to say, "Yep, LooseVersion does
+# the Right Thing" (ie. the code matches the conception).  But I'd rather
+# have a conception that matches common notions about version numbers.
+
+
+if sys.version_info >= (3,):
+
+    class _Py2Int(int):
+        """Integer object that compares < any string"""
+
+        def __gt__(self, other):
+            if isinstance(other, str):
+                return False
+            return super().__gt__(other)
+
+        def __lt__(self, other):
+            if isinstance(other, str):
+                return True
+            return super().__lt__(other)
+
+else:
+    _Py2Int = int
+
+
+class LooseVersion(object):
+    """Version numbering for anarchists and software realists.
+    Implements the standard interface for version number classes as
+    described above.  A version number consists of a series of numbers,
+    separated by either periods or strings of letters.  When comparing
+    version numbers, the numeric components will be compared
+    numerically, and the alphabetic components lexically.  The following
+    are all valid version numbers, in no particular order:
+
+        1.5.1
+        1.5.2b2
+        161
+        3.10a
+        8.02
+        3.4j
+        1996.07.12
+        3.2.pl0
+        3.1.1.6
+        2g6
+        11g
+        0.960923
+        2.2beta29
+        1.13++
+        5.5.kw
+        2.0b1pl0
+
+    In fact, there is no such thing as an invalid version number under
+    this scheme; the rules for comparison are simple and predictable,
+    but may not always give the results you want (for some definition
+    of "want").
+    """
+
+    component_re = re.compile(r"(\d+ | [a-z]+ | \.)", re.VERBOSE)
+
+    def __init__(self, vstring=None):
+        if vstring:
+            self.parse(vstring)
+
+    def __eq__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return NotImplemented
+        return c == 0
+
+    def __lt__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return NotImplemented
+        return c < 0
+
+    def __le__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return NotImplemented
+        return c <= 0
+
+    def __gt__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return NotImplemented
+        return c > 0
+
+    def __ge__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return NotImplemented
+        return c >= 0
+
+    def parse(self, vstring):
+        # I've given up on thinking I can reconstruct the version string
+        # from the parsed tuple -- so I just store the string here for
+        # use by __str__
+        self.vstring = vstring
+        components = [x for x in self.component_re.split(vstring) if x and x != "."]
+        for i, obj in enumerate(components):
+            try:
+                components[i] = int(obj)
+            except ValueError:
+                pass
+
+        self.version = components
+
+    def __str__(self):
+        return self.vstring
+
+    def __repr__(self):
+        return "LooseVersion ('%s')" % str(self)
+
+    def _cmp(self, other):
+        other = self._coerce(other)
+        if other is NotImplemented:
+            return NotImplemented
+
+        if self.version == other.version:
+            return 0
+        if self.version < other.version:
+            return -1
+        if self.version > other.version:
+            return 1
+        return NotImplemented
+
+    @classmethod
+    def _coerce(cls, other):
+        if isinstance(other, cls):
+            return other
+        elif isinstance(other, str):
+            return cls(other)
+        elif "distutils" in sys.modules:
+            # Using this check to avoid importing distutils and suppressing the warning
+            try:
+                from distutils.version import LooseVersion as deprecated
+            except ImportError:
+                return NotImplemented
+            if isinstance(other, deprecated):
+                return cls(str(other))
+        return NotImplemented
+
+
+class LooseVersion2(LooseVersion):
+    """LooseVersion variant that restores Python 2 semantics
+
+    In Python 2, comparing LooseVersions where paired components could be string
+    and int always resulted in the string being "greater". In Python 3, this produced
+    a TypeError.
+    """
+
+    def parse(self, vstring):
+        # I've given up on thinking I can reconstruct the version string
+        # from the parsed tuple -- so I just store the string here for
+        # use by __str__
+        self.vstring = vstring
+        components = [x for x in self.component_re.split(vstring) if x and x != "."]
+        for i, obj in enumerate(components):
+            try:
+                components[i] = _Py2Int(obj)
+            except ValueError:
+                pass
+
+        self.version = components

--- a/opensvc/tests/test_utilities.py
+++ b/opensvc/tests/test_utilities.py
@@ -16,6 +16,7 @@ from utilities.lazy import *
 from utilities.net.converters import *
 from utilities.proc import is_exe, justcall, lcall, qcall, vcall, which, call, drop_option
 from utilities.render.banner import banner
+from utilities.semver import Semver
 from utilities.string import bencode, bdecode, empty_string, is_string
 
 
@@ -626,3 +627,72 @@ class TestAbbrev:
     )
     def test_it_correctly_trim_nodes(input_nodes, expected_nodes):
         assert abbrev(input_nodes) == expected_nodes
+
+
+@pytest.mark.ci
+class TestSemver:
+    @staticmethod
+    @pytest.mark.parametrize(
+    "a,b,eq,lt",
+    [
+        # ─────────────────────────────
+        # Equality (core correctness)
+        # ─────────────────────────────
+        ("1.0.0", "1.0.0", True, False),
+        ("1.0.0+build1", "1.0.0+build2", True, False),
+        ("1.0.0-alpha1+build1", "1.0.0-alpha1+build2", True, False),
+        ("1.0.0-alpha1", "1.0.0-alpha1", True, False),
+        ("17.5.0", "17.5.0", True, False),
+
+        # ─────────────────────────────
+        # Basic numeric ordering
+        # ─────────────────────────────
+        ("1.0.1", "1.0.2", False, True),
+        ("1.1.0", "1.2.0", False, True),
+        ("1.9.0", "1.10.0", False, True),
+        ("17.5.2", "17.5.3", False, True),
+        ("17.5.5-aaa", "17.5.4-bbb", False, False),
+        ("17.5.5-ddd", "17.5.4-bbb", False, False),
+        ("17.5.3-aaa", "17.5.4-bbb", False, True),
+        ("17.5.3-ddd", "17.5.4-bbb", False, True),
+        # ─────────────────────────────
+        # Pre-release vs release
+        # ─────────────────────────────
+        ("1.0.0-alpha", "1.0.0", False, True),
+        ("1.0.0-rc.1", "1.0.0", False, True),
+
+        # ─────────────────────────────
+        # Pre-release ordering (same base version)
+        # ─────────────────────────────
+        ("1.0.0-alpha", "1.0.0-beta", False, True),
+        ("1.0.0-alpha.1", "1.0.0-alpha.2", False, True),
+        ("1.0.0-alpha.2", "1.0.0-alpha.10", False, True),
+        ("1.0.0-alpha.beta", "1.0.0-beta", False, True),
+
+        # ─────────────────────────────
+        # Numeric vs string identifiers
+        # ─────────────────────────────
+        ("1.0.0-alpha.1", "1.0.0-alpha.beta", False, True),
+        ("1.0.0-beta.2", "1.0.0-beta.11", False, True),
+
+        # ─────────────────────────────
+        # Length rule (shorter < longer if prefix equal)
+        # ─────────────────────────────
+        ("1.0.0-alpha", "1.0.0-alpha.1", False, True),
+        ("1.0.0-alpha.1", "1.0.0-alpha.1.1", False, True),
+
+        # ─────────────────────────────
+        # Edge mixed prerelease forms
+        # ─────────────────────────────
+        ("1.0.0-0.1", "1.0.0-alpha", False, True),
+    ],
+    )
+    def test_semver_compare(a, b, eq, lt):
+        v_a = Semver.parse(a)
+        v_b = Semver.parse(b)
+
+        assert (v_a == v_b) is eq, "== failed"
+        assert (v_a < v_b) is lt, "< failed"
+
+        # important invariant: cannot be both equal and less
+        assert not (eq and lt)

--- a/opensvc/utilities/asset/osf1.py
+++ b/opensvc/utilities/asset/osf1.py
@@ -47,7 +47,7 @@ class Asset(BaseAsset):
         return ' '.join(l[2:4])
 
     def _get_os_kernel(self):
-        from distutils.version import LooseVersion as V # pylint: disable=no-name-in-module,import-error
+        from foreign.looseversion import LooseVersion as V # pylint: disable=no-name-in-module,import-error
         cmd = ['dupatch', '-track', '-type', 'kit', '-nolog']
         out, err, ret = _justcall(cmd)
         l = []

--- a/opensvc/utilities/semver.py
+++ b/opensvc/utilities/semver.py
@@ -1,32 +1,79 @@
 import re
+from functools import total_ordering
 
-SEMVER_RE = r'^([0-9]+).([0-9]+).([0-9]+)$'
+_semver_re = re.compile(
+    r"""
+    ^
+    (?P<major>0|[1-9]\d*)\.
+    (?P<minor>0|[1-9]\d*)\.
+    (?P<patch>0|[1-9]\d*)
+    (?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?
+    (?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
+    $""",
+    re.VERBOSE,
+)
 
-
+@total_ordering
 class Semver(object):
-    def __init__(self, major=0, minor=0, patch=0):
+    """
+    Represents a semantic version as defined by the Semantic Versioning 2.0.0 standard.
+
+    This class provides functionalities to create, parse, and compare semantic version strings.
+    Semantic versioning is a versioning scheme intended for managing dependencies in software projects.
+    It follows the format `MAJOR.MINOR.PATCH` where changes to each segment indicate specific types of updates.
+    Additionally, the class supports optional prerelease and build metadata fields that allow to specify
+    more detailed versioning information.
+
+    :ivar major: The major version number. Incremented for incompatible changes.
+    :type major: int
+    :ivar minor: The minor version number. Incremented for backward-compatible functionality.
+    :type minor: int
+    :ivar patch: The patch version number. Incremented for backward-compatible bug fixes.
+    :type patch: int
+    :ivar prerelease: An optional prerelease identifier string (e.g., alpha, beta).
+    :type prerelease: str
+    :ivar build: An optional build metadata string (e.g., build identifiers for internal use).
+    :type build: str
+    """
+    def __init__(self, major=0, minor=0, patch=0, prerelease=None, build=None):
         self.major = int(major)
         self.minor = int(minor)
         self.patch = int(patch)
+        self.prerelease = prerelease or None
+        self.build = build or None
 
     def __str__(self):
-        return "%d.%d.%d" % (self.major, self.minor, self.patch)
+        s = "%d.%d.%d" % (self.major, self.minor, self.patch)
+        if self.prerelease:
+            s += "-%s" % self.prerelease
+        if self.build:
+            s += "+%s" % self.build
+        return s
 
     @classmethod
     def parse(cls, s):
         if not isinstance(s, str):
             return cls()
-        l = re.findall(SEMVER_RE, s)
-        if len(l) != 1 or len(l[0]) != 3:
-            return cls()
-        return cls(major=int(l[0][0]), minor=int(l[0][1]), patch=int(l[0][2]))
+        m = re.match(_semver_re, s)
+        if not m:
+            raise ValueError("Invalid semver")
+        return cls(
+            major=int(m.group("major")),
+            minor=int(m.group("minor")),
+            patch=int(m.group("patch")),
+            prerelease=m.group("prerelease"),
+            build=m.group("buildmetadata"))
 
     def __eq__(self, other):
-        if (self.major, self.minor, self.patch) == (other.major, other.minor, other.patch):
+        if not isinstance(other, Semver):
+            return False
+        if (self.major, self.minor, self.patch, self.prerelease) == (other.major, other.minor, other.patch, other.prerelease):
             return True
         return False
 
     def __lt__(self, other):
+        if not isinstance(other, Semver):
+            return NotImplemented
         if self.major < other.major:
             return True
         elif self.major == other.major:
@@ -35,7 +82,62 @@ class Semver(object):
             elif self.minor == other.minor:
                 if self.patch < other.patch:
                     return True
+                elif self.patch == other.patch:
+                    return self._parse_prerelease() < other._parse_prerelease()
+
         return False
 
-    def __le__(self, other):
-        return (self < other) or (self == other)
+    def _parse_prerelease(self):
+        """
+        Parses the prerelease component of a version string into a tuple
+        that can be used for comparing versions by precedence according to
+        the https://semver.org rules.
+
+        The method differentiates between numeric and alphanumeric
+        identifiers in the prerelease string, and constructs a precedence
+        tuple accordingly.
+
+        :return: A tuple representing the parsed prerelease component
+                 with numeric and alphanumeric identifiers.
+        :rtype: tuple
+        """
+        if not self.prerelease:
+            return (1,)  # no prerelease = highest precedence
+
+        parts = []
+        for p in self.prerelease.split("."):
+            if p.isdigit():
+                parts.append((0, int(p)))  # numeric identifiers
+            else:
+                parts.append((1, p))  # alphanumeric identifiers
+        return (0, parts)
+
+    def __hash__(self):
+        return hash((self.major, self.minor, self.patch, self.prerelease))
+
+def as_semver(s):
+    """
+    Do our best to convert a string to a semver object from calendar versioning.
+    Remove removing leading zeros from major, minor, patch version components
+    before the first "-", or "+", if present.
+    Docker example: 17.05.0-ce -> 17.5.0-ce.
+    """
+    has_release = False
+    has_build = False
+    suffix = ""
+    if '-' in s:
+        has_release = True
+        base, suffix = s.split('-', 1)
+    elif '+' in s:
+        has_build = True
+        base, suffix = s.split('+', 1)
+    else:
+        base = s
+    clean_base = re.sub(r'(^|\.)0+(?=\d)', r'\1', base)
+    if has_release:
+        clean_v = "%s-%s" % (clean_base, suffix)
+    elif has_build:
+        clean_v = "%s+%s" % (clean_base, suffix)
+    else:
+        clean_v = clean_base
+    return Semver.parse(clean_v)

--- a/opensvc/utilities/subsystems/docker.py
+++ b/opensvc/utilities/subsystems/docker.py
@@ -8,7 +8,6 @@ import json
 import os
 import re
 import time
-from distutils.version import LooseVersion as V # pylint: disable=no-name-in-module,import-error
 
 import utilities.lock
 import core.status
@@ -17,6 +16,7 @@ import core.exceptions as ex
 from env import Env
 from utilities.lazy import threadsafe_lazy as lazy, unset_lazy, set_lazy
 from utilities.proc import justcall
+from foreign.looseversion import LooseVersion as V
 
 def has_docker(program_list):
     for exe in program_list:

--- a/var/compliance/com.opensvc/firmware.py
+++ b/var/compliance/com.opensvc/firmware.py
@@ -2,9 +2,8 @@
 
 import os
 import sys
-import json
-from distutils.version import LooseVersion as V
 from subprocess import *
+from foreign.looseversion import LooseVersion as V
 
 sys.path.append(os.path.dirname(__file__))
 

--- a/var/compliance/com.opensvc/package.py
+++ b/var/compliance/com.opensvc/package.py
@@ -332,7 +332,7 @@ zlib                                                               ALL  @@R:zlib
 
         ll = []
         ix86_added = False
-        from distutils.version import LooseVersion as V
+        from foreign.looseversion import LooseVersion as V
         for _pkgname, _version in sorted(l, key=lambda x: V(x[1]), reverse=True):
             pkgarch = _pkgname.split('.')[-1]
             if pkgarch not in ('i386', 'i586', 'i686', 'ia32'):

--- a/var/compliance/com.opensvc/vuln.py
+++ b/var/compliance/com.opensvc/vuln.py
@@ -68,7 +68,7 @@ import sys
 import re
 import tempfile
 from subprocess import *
-from distutils.version import LooseVersion as V
+from foreign.looseversion import LooseVersion as V
 from utilities import which
 
 


### PR DESCRIPTION
## Summary

This pull request modernizes version comparison by replacing `distutils.version.LooseVersion` (removed in Python 3.12) with `foreign.looseversion.LooseVersion` and migrating to a custom `Semver` class for semantic versioning. It ensures compliance with Semantic Versioning 2.0.0 and enhances version-related functionality. Key changes include:

- Vendoring `foreign.looseversion.LooseVersion` under PSF license for backward compatibility with pre-3.12 environments.
- Replacing `LooseVersion` with `Semver.as_semver` for a more robust and future-proof version management solution.
- Improving semantic version parsing with support for `prerelease` identifiers, `build` metadata, and proper precedence comparison logic.
- Adding extensive unit tests to validate `Semver` behavior.
