### PR TITLE
Add oc3 action queuing

### DIFF
--- a/opensvc/core/node/node.py
+++ b/opensvc/core/node/node.py
@@ -2400,6 +2400,52 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
         return default
 
     def dequeue_actions(self):
+        if self.oc3_version() >= Semver(3, 0, 2):
+            self.dequeue_actions_oc3()
+        else:
+            self.dequeue_actions_oc2()
+
+    def dequeue_actions_oc3(self):
+        api_verb = "GET"
+        api_path = oc3path.FEED_NODE_ACTIONQ
+        status_code, resp = self.oc3_request_feed(api_verb, api_path)
+        self.oc3_assert_status_code(api_verb, api_path, status_code, resp, expected=[200])
+        try:
+            actions = resp.get("actions", [])
+            self.log.debug("Received actions from OC3: %s", actions)
+            ids = [action["id"] for action in actions]
+            api_verb = "POST"
+            api_path = oc3path.FEED_NODE_ACTIONQ_RUNNING
+            self.log.debug("acknowledge actions from OC3: %s", ids)
+            status_code, resp = self.oc3_request_feed(api_verb, api_path, data={"ids": ids})
+            self.oc3_assert_status_code(api_verb, api_path, status_code, resp, expected=[202])
+            self.log.debug("acknowledge actions from OC3 done")
+            self.dequeue_actions_oc3_run(actions)
+        except:
+            pass
+
+    def dequeue_actions_oc3_run(self, actions):
+        api_verb = "POST"
+        api_path = oc3path.FEED_NODE_ACTIONQ_DONE
+        from utilities.rfc3339 import RFC3339
+
+        rfc3339 = RFC3339()
+
+        for action in actions:
+            ret, out, err = self.dequeue_action(action)
+            out = ANSI_ESCAPE.sub('', out)
+            err = ANSI_ESCAPE.sub('', err)
+            action_result = {
+                "id": action.get('id'),
+                "ret": ret,
+                "stdout": ANSI_ESCAPE.sub('', out),
+                "stderr": ANSI_ESCAPE.sub('', err),
+                "dequeued_at": rfc3339.now()
+            }
+            status_code, resp = self.oc3_request_feed(api_verb, api_path, data=action_result)
+            self.oc3_assert_status_code(api_verb, api_path, status_code, resp, expected=[202])
+
+    def dequeue_actions_oc2(self):
         """
         The dequeue_actions node action entrypoint.
         Poll the collector action queue until emptied.

--- a/opensvc/core/oc3path/__init__.py
+++ b/opensvc/core/oc3path/__init__.py
@@ -3,6 +3,10 @@
 # Server api paths
 SERVER_NODE_REGISTER = "/api/auth/node"
 
+FEED_NODE_ACTIONQ = "/api/node/actionq"
+FEED_NODE_ACTIONQ_DONE = "/api/node/actionq/done"
+FEED_NODE_ACTIONQ_RUNNING = "/api/node/actionq/running"
+
 # Feeder api paths
 FEED_DAEMON_PING = "/api/daemon/ping"
 FEED_DAEMON_STATUS = "/api/daemon/status"

--- a/opensvc/daemon/collector.py
+++ b/opensvc/daemon/collector.py
@@ -7,6 +7,7 @@ import os
 import logging
 import time
 from copy import deepcopy
+from socket import socket, AF_INET, SOCK_STREAM
 
 import daemon.shared as shared
 import core.oc3path as oc3path
@@ -353,6 +354,10 @@ class Collector(shared.OsvcThread):
                         # purge configs sent of object_without_config
                         # => next run will send service config to collector
                         self.purge_configs_sent(object_without_config)
+                    nodes_with_action_queued = response_body.get("node_with_action_queued", [])
+                    if nodes_with_action_queued is not None and len(nodes_with_action_queued) > 0:
+                        for nodename in nodes_with_action_queued:
+                            self.queue_actions(nodename)
             else:
                 shared.NODE.collector.call("push_daemon_status", data, list(self.last_status_changed))
         except Exception as exc:
@@ -383,6 +388,10 @@ class Collector(shared.OsvcThread):
                         # purge configs sent of object_without_config
                         # => next run will send service config to collector
                         self.purge_configs_sent(object_without_config)
+                    nodes_with_action_queued = response_body.get("node_with_action_queued", [])
+                    if nodes_with_action_queued is not None and len(nodes_with_action_queued) > 0:
+                        for nodename in nodes_with_action_queued:
+                            self.queue_actions(nodename)
                 elif status_code == 204:
                     self.log.debug("ping rejected, collector ask for resync")
                     self.send_daemon_status(data)
@@ -566,3 +575,12 @@ class Collector(shared.OsvcThread):
             if version > null_version:
                 self.log.warning("oc3 version preserve cache (%s %s error: %s)", api_verb, api_path, str(err))
         return version
+
+    def queue_actions(self, nodename):
+        # TODO improve nodename and port detection
+        self.log.info("send dequeue_actions to node %s...", nodename)
+        sock = socket(AF_INET, SOCK_STREAM)
+        sock.settimeout(1)
+        sock.connect((nodename, 1214))
+        sock.send(b"dequeue_actions")
+        sock.close()

--- a/opensvc/utilities/rfc3339.py
+++ b/opensvc/utilities/rfc3339.py
@@ -15,6 +15,9 @@ class RFC3339(object):
     def from_epoch(self, t):
         return datetime.fromtimestamp(t).strftime(self.format)
 
+    def now(self):
+        return datetime.now().strftime(self.format)
+
 
 class RFC3339Formatter(logging.Formatter):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION

This pull request introduces the following changes:
- **Action Queuing:**
  - Added a `queue_actions` method to manage action queuing via socket communication.
  - Integrated support for OC3 action queue handling through the `dequeue_actions_oc3` method.
- **RFC3339 Time Formatting:**
  - Implemented a `now` method to format the current time in RFC3339 format.

