### PR TITLE
Refactor postremove: consolidate purge and remove cleanup logic

### DIFF
--- a/bin/postremove
+++ b/bin/postremove
@@ -15,17 +15,12 @@ clean_systemd() {
 }
 
 case "$1" in
-purge)
-        rm -rf /var/lib/opensvc /var/log/opensvc /etc/opensvc /usr/share/opensvc
-        rm -f /etc/default/opensvc 
-        ;;
-
 remove)
         clean_systemd
         rm -f /etc/profile.d/opensvc.sh
         ;;
 
-upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+purge|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
         ;;
 
 *)


### PR DESCRIPTION
- Removed purge case: scripted folder deletion is not a good practise
- Avoid potential outage if opensvc package is purged while opensvc v3 is running