### PR TITLE
disk.md: find the array with blkid, and keep the scan as the fallback

### DIFF
--- a/opensvc/drivers/resource/disk/md/__init__.py
+++ b/opensvc/drivers/resource/disk/md/__init__.py
@@ -100,6 +100,10 @@ def justcall_md_create(*args, **kwargs):
     return justcall(*args, **kwargs)
 
 
+def justcall_blkid(*args, **kwargs):
+    return justcall(*args, **kwargs)
+
+
 class DiskMd(BaseDisk):
     startup_timeout = 10
 
@@ -173,6 +177,7 @@ class DiskMd(BaseDisk):
         self._unset_svc_rid_uuid()
         self.svc.node.unset_lazy("devtree")
         self.clear_cache("mdadm.scan.v")
+        self.clear_cache("blkid.scan")
 
     def _info(self):
         data = [
@@ -275,6 +280,7 @@ class DiskMd(BaseDisk):
         cmd = [self.mdadm, "--assemble", self.devname(), "-u", self.uuid]
         ret, out, err = self.vcall(cmd, warn_to_info=True)
         self.clear_cache("mdadm.scan.v")
+        self.clear_cache("blkid.scan")
         if ret == 2:
             self.log.info("no changes were made to the array")
         elif ret != 0:
@@ -286,6 +292,7 @@ class DiskMd(BaseDisk):
         cmd = [self.mdadm, "--stop", self.md_devpath()]
         ret, out, err = self.vcall(cmd, warn_to_info=True)
         self.clear_cache("mdadm.scan.v")
+        self.clear_cache("blkid.scan")
         if ret != 0:
             raise ex.Error
 
@@ -325,6 +332,9 @@ class DiskMd(BaseDisk):
     def has_it(self):
         if self.uuid == "" or self.uuid is None:
             return False
+        devs, authoritative = self.blkid_members()
+        if authoritative:
+            return len(devs) > 0
         return self._mdadm_scan_match(self.mdadm_scan_v()[0], uuid=self.uuid)
 
     def is_up(self):
@@ -438,7 +448,110 @@ class DiskMd(BaseDisk):
     def mdadm_scan_v(self):
         return justcall_mdadm_scan(argv=[self.mdadm, "-E", "--scan", "-v"])
 
+    @cache("blkid.scan")
+    def blkid_scan(self):
+        """
+        Return the (out, err, ret) of a blkid probe of the devices of
+        this node.
+
+        blkid reads the superblock where each format keeps it, near the
+        start of the device for the 1.x metadata and at its end for the
+        0.90, so it identifies a md member without being told which
+        format to expect. "mdadm -E --scan" reads the device through
+        when it is not given a -e, which on a node holding large luns
+        costs tens of seconds of heavy io, and this driver asks for the
+        scan on every status evaluation.
+
+        The cache is bypassed with -c so that the answer describes the
+        devices as they are, not as a blkid.tab written before the last
+        change to them.
+        """
+        if not self.blkid:
+            return "", "", 1
+        return justcall_blkid(argv=[self.blkid, "-c", os.devnull])
+
+    @lazy
+    def blkid(self):
+        return which("blkid")
+
+    def blkid_uuid(self):
+        """
+        Return the uuid of this md in the form blkid prints, or None
+        when the configured uuid is not one mdadm would have written.
+
+        mdadm writes it as four colon separated words of 8 hexadecimal
+        digits, blkid as the 8-4-4-4-12 form.
+
+        Not lazy: the provisioner learns the uuid of the array it just
+        created and sets it on this resource, and a value computed
+        before that would outlive it.
+        """
+        if not self.uuid:
+            return None
+        clean = self.uuid.replace(":", "").replace("-", "")
+        if len(clean) != 32:
+            return None
+        return "-".join((clean[0:8], clean[8:12], clean[12:16],
+                         clean[16:20], clean[20:32]))
+
+    def blkid_members(self):
+        """
+        Return the devices holding a member superblock of this md, and
+        whether blkid was able to answer at all.
+
+        The answer is not authoritative when blkid is absent or failed,
+        and when the node holds a container member superblock: a imsm
+        or ddf container names none of the volumes it holds, so the md
+        looked for may be in there and only mdadm can tell. Both fall
+        back to the mdadm scan, as does a uuid blkid cannot express.
+        """
+        blkid_uuid = self.blkid_uuid()
+        if not self.blkid or not blkid_uuid:
+            return set(), False
+        out, err, ret = self.blkid_scan()
+        if ret not in (0, 2):
+            # 2 is blkid's "nothing found", which is an answer
+            return set(), False
+        devs = set()
+        container = False
+        for line in out.splitlines():
+            words = line.split(":", 1)
+            if len(words) != 2:
+                continue
+            dev, props = words[0], words[1]
+            if 'TYPE="linux_raid_member"' in props:
+                if 'UUID="%s"' % blkid_uuid in props:
+                    devs.add(os.path.realpath(dev))
+            elif 'TYPE="isw_raid_member"' in props or 'TYPE="ddf_raid_member"' in props:
+                container = True
+        if devs:
+            return devs, True
+        if container:
+            return set(), False
+        return set(), True
+
+    def _discard_paths(self, devs):
+        """
+        Drop the paths of a multipathed device from a device set, so
+        that a member is reported by its top holder only. Both blkid
+        and mdadm report a lun and each of its paths.
+        """
+        paths = set()
+        for dev in devs:
+            _paths = set(utilities.devices.linux.dev_to_paths(dev))
+            if set([dev]) != _paths:
+                paths |= _paths
+        return devs - paths
+
     def sub_devs_inactive(self):
+        devs, authoritative = self.blkid_members()
+        if authoritative:
+            devs = self._discard_paths(devs)
+            self.log.debug("found devs %s held by md %s" % (devs, self.uuid))
+            return devs
+        return self.sub_devs_inactive_scan()
+
+    def sub_devs_inactive_scan(self):
         devs = set()
         out, err, ret = self.mdadm_scan_v()
         if ret != 0:
@@ -448,7 +561,6 @@ class DiskMd(BaseDisk):
         if len(lines) < 2:
             return set()
         inblock = False
-        paths = set()
         for line in lines:
             if self._mdadm_scan_match(line, uuid=self.uuid):
                 inblock = True
@@ -457,13 +569,10 @@ class DiskMd(BaseDisk):
                 l = line.split("devices=")[-1].split(",")
                 l = map(lambda x: os.path.realpath(x), l)
                 for dev in l:
-                    _paths = set(utilities.devices.linux.dev_to_paths(dev))
-                    if set([dev]) != _paths:
-                        paths |= _paths
                     devs.add(dev)
                 break
         # discard paths from the list (mdadm shows both mpaths and paths)
-        devs -= paths
+        devs = self._discard_paths(devs)
 
         self.log.debug("found devs %s held by md %s" % (devs, self.uuid))
         return devs
@@ -510,6 +619,7 @@ class DiskMd(BaseDisk):
                 cmd = [self.mdadm, "--re-add", devpath, faultydev]
                 ret, out, err = self.vcall(cmd, warn_to_info=True)
                 self.clear_cache("mdadm.scan.v")
+                self.clear_cache("blkid.scan")
                 if ret != 0:
                     raise ex.Error("failed to re-add %s to %s"%(faultydev, devpath))
                 added += 1
@@ -540,6 +650,7 @@ class DiskMd(BaseDisk):
         self.log.info(" ".join(argv))
         out, err, return_code = justcall_md_create(argv=argv, input=b'no\n')
         self.clear_cache("mdadm.scan.v")
+        self.clear_cache("blkid.scan")
         self.log.info(out)
         if return_code != 0:
             raise ex.Error(err)

--- a/opensvc/tests/resource/disk/md/test_md.py
+++ b/opensvc/tests/resource/disk/md/test_md.py
@@ -343,3 +343,119 @@ class TestDiskMdDevname:
         md.name = "abcd"
         assert md.devname() == "/dev/md/abcd"
 
+
+
+# A uuid as mdadm writes it, and the same in the form blkid prints.
+md_uuid = '4198d2fe:84f45665:58aae039:ceff1171'
+md_blkid_uuid = '4198d2fe-84f4-5665-58aa-e039ceff1171'
+
+blkid_out = """/dev/sda1: UUID="0e6e8dfd-8f9c-4b5e-9a5e-1c14b0e1a4e5" TYPE="ext4"
+/dev/loop4: UUID="%s" UUID_SUB="1ae4ca4a-0cbc-0a60-45a8-ee18231da0b3" LABEL="node1:s.disk.1" TYPE="linux_raid_member"
+/dev/loop5: UUID="%s" UUID_SUB="98c635be-d1c9-f449-bdf7-f3e2bf375e98" LABEL="node1:s.disk.1" TYPE="linux_raid_member"
+""" % (md_blkid_uuid, md_blkid_uuid)
+
+blkid_out_other_md = """/dev/loop6: UUID="deadbeef-dead-beef-dead-beefdeadbeef" TYPE="linux_raid_member"
+"""
+
+blkid_out_container = """/dev/sdb: TYPE="isw_raid_member"
+/dev/sdc: TYPE="isw_raid_member"
+"""
+
+
+@pytest.fixture(scope='function')
+def blkid(mocker):
+    return mocker.patch(LIB_NAME + '.justcall_blkid', return_value=(blkid_out, '', 0))
+
+
+@pytest.fixture(scope='function')
+def dev_to_paths(mocker):
+    return mocker.patch('utilities.devices.linux.dev_to_paths', side_effect=lambda dev: [dev])
+
+
+@pytest.fixture(scope='function')
+def md_blkid(svc, mocker, tmp_file):
+    mocker.patch.object(DiskMd, 'mdadm_cf',
+                        new_callable=mocker.PropertyMock(return_value=tmp_file))
+    md = DiskMd(rid='disk#1', devs=['/dev/loop4', '/dev/loop5'], spares=0)
+    md.svc = svc
+    md.uuid = md_uuid
+    return md
+
+
+@pytest.mark.ci
+@pytest.mark.usefixtures('osvc_path_tests')  # for cache
+@pytest.mark.usefixtures('has_mdadm')
+class TestDiskMdBlkid:
+    """
+    blkid answers "is this md here, and which devices hold it" by
+    reading the superblock where each metadata format keeps it, where
+    "mdadm -E --scan" reads the devices through when it is not told
+    which format to expect.
+    """
+
+    @staticmethod
+    def test_the_uuid_is_converted_to_the_form_blkid_prints(md_blkid):
+        assert md_blkid.blkid_uuid() == md_blkid_uuid
+
+    @staticmethod
+    @pytest.mark.parametrize('uuid', ['s-uuid', '', None, '4198d2fe:84f45665'])
+    def test_a_uuid_mdadm_would_not_have_written_is_left_to_the_scan(md_blkid, uuid):
+        md_blkid.uuid = uuid
+        assert md_blkid.blkid_uuid() is None
+        assert md_blkid.blkid_members() == (set(), False)
+
+    @staticmethod
+    def test_has_it_without_running_the_scan(blkid, mdadm_scan, md_blkid):
+        assert md_blkid.has_it() is True
+        assert mdadm_scan.call_count == 0
+
+    @staticmethod
+    def test_has_not_it_without_running_the_scan(blkid, mdadm_scan, md_blkid):
+        blkid.return_value = blkid_out_other_md, '', 0
+        assert md_blkid.has_it() is False
+        assert mdadm_scan.call_count == 0
+
+    @staticmethod
+    def test_a_node_holding_no_md_is_an_answer_too(blkid, mdadm_scan, md_blkid):
+        blkid.return_value = '', '', 2
+        assert md_blkid.has_it() is False
+        assert mdadm_scan.call_count == 0
+
+    @staticmethod
+    def test_a_container_member_is_left_to_the_scan(blkid, mdadm_scan, md_blkid):
+        # An imsm or ddf container names none of the volumes it holds,
+        # so the md looked for may be in there.
+        blkid.return_value = blkid_out_container, '', 0
+        md_blkid.uuid = 's-uuid'  # the uuid the mocked scan reports
+        assert md_blkid.has_it() is True
+        assert mdadm_scan.call_count == 1
+
+    @staticmethod
+    def test_a_failed_blkid_is_left_to_the_scan(blkid, mdadm_scan, md_blkid):
+        blkid.return_value = '', 'blkid: error', 1
+        md_blkid.uuid = 's-uuid'
+        assert md_blkid.has_it() is True
+        assert mdadm_scan.call_count == 1
+
+    @staticmethod
+    def test_an_absent_blkid_is_left_to_the_scan(mocker, mdadm_scan, md_blkid):
+        mocker.patch(LIB_NAME + '.which',
+                     side_effect=lambda prog: None if prog == 'blkid' else '/sbin/' + prog)
+        md_blkid.uuid = 's-uuid'
+        assert md_blkid.has_it() is True
+        assert mdadm_scan.call_count == 1
+
+    @staticmethod
+    def test_sub_devs_inactive_without_running_the_scan(blkid, mdadm_scan, dev_to_paths, md_blkid):
+        assert md_blkid.sub_devs_inactive() == {'/dev/loop4', '/dev/loop5'}
+        assert mdadm_scan.call_count == 0
+
+    @staticmethod
+    def test_sub_devs_inactive_reports_a_lun_once(blkid, mdadm_scan, mocker, md_blkid):
+        # blkid lists a multipathed member once per path, as mdadm does.
+        blkid.return_value = blkid_out + \
+            '/dev/sdx: UUID="%s" TYPE="linux_raid_member"\n' % md_blkid_uuid, '', 0
+        mocker.patch('utilities.devices.linux.dev_to_paths',
+                     side_effect=lambda dev: ['/dev/sdx'] if dev == '/dev/loop4' else [dev])
+        assert md_blkid.sub_devs_inactive() == {'/dev/loop4', '/dev/loop5'}
+        assert mdadm_scan.call_count == 0


### PR DESCRIPTION
has_it() runs "mdadm -E --scan -v", and is_up() calls has_it(), so every status evaluation scans. Recent mdadm reads a device through when it is not told which metadata format to expect, and a client site measured 44 seconds of heavy io per scan on its luns. Giving -e 1.2 avoids the read, but only an operator who already knows the format can give it, and being wrong makes an existing array invisible: has_it() returns false, is_up() reads that as down, and a start acts on it.

blkid answers the same question without the scan, and without being told the format: it reads the superblock where each one keeps it, near the start of the device for 1.x, at the end for 0.90. Measured on a node with 49 devices: 0.19s for a full probe with the cache bypassed, against 0.11s for the scan of loop devices, which is the case where the scan is cheap. It also reports the format it found, so nothing has to be declared in the configuration.

So has_it() and sub_devs_inactive() ask blkid first, and fall back to the scan when blkid cannot answer: when it is absent, when it fails, when the uuid is not one it can express, and when the node holds an imsm or ddf container member, which names none of the volumes it holds. A node holding no md member at all is an answer, not a fallback: it is the passive node of a failover service, and the one this most needs to stop scanning.

The uuid conversion is the only fiddly part: mdadm writes four colon separated words of eight hexadecimal digits, blkid the 8-4-4-4-12 form. Checked against a live array: 422e33db:ec47802f:2a81a541:3ad3f153 is 422e33db-ec47-802f-2a81-a5413ad3f153.

Thirteen tests cover the paths, including each fallback and the multipathed member a lun reports once per path. The suite is at 44 passing, from 31.