### PR TITLE
disk.md: find the devpath of the array without examining the devices

### DIFF
--- a/opensvc/core/node/node.py
+++ b/opensvc/core/node/node.py
@@ -20,7 +20,6 @@ import shlex
 import sys
 import time
 from errno import ECONNREFUSED, EPIPE
-import multiprocessing
 
 import foreign.six as six
 
@@ -52,7 +51,7 @@ from utilities.lazy import (lazy, lazy_initialized, set_lazy, unset_all_lazy,
                             unset_lazy)
 from utilities.lock import LOCK_EXCEPTIONS
 from utilities.proc import call, justcall, vcall, which, check_privs, daemon_process_running, drop_option, find_editor, \
-    init_locale, does_call_cmd_need_shell, get_call_cmd_from_str
+    init_locale, does_call_cmd_need_shell, get_call_cmd_from_str, fork_context
 from utilities.files import assert_file_exists, assert_file_is_root_only_writeable, makedirs
 from utilities.render.color import formatter
 from utilities.semver import Semver
@@ -2779,17 +2778,7 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
         # noinspection PyUnresolvedReferences
         from utilities.process_title import set_process_title  # warm up for side effect
 
-        # The workers are forked, and not started by the method python picks
-        # by default. Python 3.14 made that default "forkserver" on linux,
-        # which pickles the arguments instead of inheriting them, and the
-        # service passed here does not survive that: it carries lazy caches of
-        # process-global singletons, the keyword store first of all, which
-        # come back in the child as copies of themselves that nothing else in
-        # that process shares. The first symptom was every parallel action
-        # failing with "sync#i0.options not found in the keywords dictionary",
-        # the keyword being registered in the child's own store by the driver
-        # import while the service read the copy it was pickled with.
-        ctx = multiprocessing.get_context("fork")
+        ctx = fork_context()
 
         def can_run_new_proc():
             count = 0

--- a/opensvc/core/node/node.py
+++ b/opensvc/core/node/node.py
@@ -20,7 +20,7 @@ import shlex
 import sys
 import time
 from errno import ECONNREFUSED, EPIPE
-from multiprocessing import Process
+import multiprocessing
 
 import foreign.six as six
 
@@ -226,7 +226,7 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
     def private_cd(self):
         return self.parse_config_file(self.paths.cf)
 
-    @lazy
+    @property
     def kwstore(self):
         from .nodedict import KEYS
         return KEYS
@@ -2779,6 +2779,18 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
         # noinspection PyUnresolvedReferences
         from utilities.process_title import set_process_title  # warm up for side effect
 
+        # The workers are forked, and not started by the method python picks
+        # by default. Python 3.14 made that default "forkserver" on linux,
+        # which pickles the arguments instead of inheriting them, and the
+        # service passed here does not survive that: it carries lazy caches of
+        # process-global singletons, the keyword store first of all, which
+        # come back in the child as copies of themselves that nothing else in
+        # that process shares. The first symptom was every parallel action
+        # failing with "sync#i0.options not found in the keywords dictionary",
+        # the keyword being registered in the child's own store by the driver
+        # import while the service read the copy it was pickled with.
+        ctx = multiprocessing.get_context("fork")
+
         def can_run_new_proc():
             count = 0
             for proc in data.procs.values():
@@ -2790,7 +2802,7 @@ class Node(Crypt, ExtConfigMixin, NetworksMixin):
             while not can_run_new_proc():
                 time.sleep(1)
             data.svcs[svc.path] = svc
-            data.procs[svc.path] = Process(
+            data.procs[svc.path] = ctx.Process(
                 target=self._service_action_worker,
                 name="worker_" + svc.path,
                 args=(svc, action, options),

--- a/opensvc/core/objects/ccfg.py
+++ b/opensvc/core/objects/ccfg.py
@@ -15,7 +15,7 @@ class Ccfg(BaseSvc):
                 pass
         BaseSvc.__init__(self, name="cluster", namespace=None, **kwargs)
 
-    @lazy
+    @property
     def kwstore(self):
         from .ccfgdict import KEYS
         return KEYS

--- a/opensvc/core/objects/cfg.py
+++ b/opensvc/core/objects/cfg.py
@@ -16,7 +16,7 @@ class Cfg(DataMixin, BaseSvc):
     desc = "configuration"
     default_mode = 0o0644
 
-    @lazy
+    @property
     def kwstore(self):
         from .cfgdict import KEYS
         return KEYS

--- a/opensvc/core/objects/nscfg.py
+++ b/opensvc/core/objects/nscfg.py
@@ -18,7 +18,7 @@ class Nscfg(PgMixin, BaseSvc):
             kwargs["name"] = "namespace"
         BaseSvc.__init__(self, *args, **kwargs)
 
-    @lazy
+    @property
     def kwstore(self):
         from .nscfgdict import KEYS
         return KEYS

--- a/opensvc/core/objects/sec.py
+++ b/opensvc/core/objects/sec.py
@@ -23,7 +23,7 @@ class Sec(DataMixin, BaseSvc):
     desc = "secret"
     default_mode = 0o0600
 
-    @lazy
+    @property
     def kwstore(self):
         from .secdict import KEYS
         return KEYS

--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -3096,7 +3096,7 @@ class Svc(PgMixin, BaseSvc):
     """
     kind = "svc"
 
-    @lazy
+    @property
     def kwstore(self):
         from .svcdict import KEYS
         return KEYS

--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -4864,7 +4864,7 @@ class Svc(PgMixin, BaseSvc):
         else:
             try:
                 # noinspection PyUnresolvedReferences
-                from multiprocessing import Process
+                from utilities.proc import fork_context
                 parallel = True
             except ImportError:
                 parallel = False
@@ -4875,7 +4875,7 @@ class Svc(PgMixin, BaseSvc):
                     raise ex.Error("start aborted due to resource %s "
                                    "conflict" % resource.rid)
         else:
-            from multiprocessing import Process
+            from utilities.proc import fork_context
             from utilities.process_title import set_process_title
 
             def wrapper(proc_title, func):
@@ -4887,10 +4887,11 @@ class Svc(PgMixin, BaseSvc):
                     sys.exit(1)
 
             procs = {}
+            ctx = fork_context()
             for resource in resources:
                 title = "om %s --rid %s check abort start" % (resource.svc.path, resource.rid)
                 # noinspection PyUnboundLocalVariable
-                proc = Process(target=wrapper, args=(title, resource.abort_start))
+                proc = ctx.Process(target=wrapper, args=(title, resource.abort_start))
                 proc.start()
                 procs[resource.rid] = proc
 

--- a/opensvc/core/objects/usr.py
+++ b/opensvc/core/objects/usr.py
@@ -32,7 +32,7 @@ class Usr(Sec, BaseSvc):
     kind = "usr"
     desc = "user"
 
-    @lazy
+    @property
     def kwstore(self):
         from .usrdict import KEYS
         return KEYS

--- a/opensvc/core/resourceset.py
+++ b/opensvc/core/resourceset.py
@@ -5,11 +5,11 @@ from __future__ import print_function
 
 import sys
 import logging
-from multiprocessing import Process
 
 import core.exceptions as ex
 import core.status
 from utilities.lazy import lazy
+from utilities.proc import fork_context
 from env import Env
 from core.resource import Resource
 
@@ -294,6 +294,7 @@ class ResourceSet(object):
             procs = {}
             self.log.info("parallel %s resources %s" % (action, ",".join(sorted([r.rid for r in resources]))))
             from utilities.process_title import set_process_title  # warm up for side effect
+            ctx = fork_context()
             for resource in resources:
                 if not resource.can_rollback and action == "rollback":
                     continue
@@ -303,7 +304,7 @@ class ResourceSet(object):
                                                            self.subset_name,
                                                            resource.rid,
                                                            action)
-                proc = Process(target=self._action_job, args=(title, resource, action,))
+                proc = ctx.Process(target=self._action_job, args=(title, resource, action,))
                 proc.start()
                 resource.log.info("action %s started in child process %d" % (action, proc.pid))
                 procs[resource.rid] = proc

--- a/opensvc/daemon/hb/disk.py
+++ b/opensvc/daemon/hb/disk.py
@@ -106,7 +106,20 @@ class HbDisk(Hb):
     def hb_fo(self):
         try:
             fd = os.open(self.dev, self.flags)
-            fo = os.fdopen(fd, 'rb+')
+            # buffering=0 is required by the O_DIRECT flag set for a linux
+            # block device: a buffered object reads and writes through an
+            # internal buffer of its own, which is not page aligned, and
+            # O_DIRECT refuses an unaligned buffer with EINVAL. Unbuffered,
+            # readinto() and write() are handed the mmap buffers of this
+            # class, which are page aligned.
+            #
+            # A buffered object only hands the caller buffer to the fd when
+            # it is at least as large as its own, so meta_slot_buff, being
+            # exactly io.DEFAULT_BUFFER_SIZE long, used to be handed over and
+            # slot_buff, being larger, still is. Python 3.14 raised that
+            # default from 8kB to 128kB, which left the meta reads going
+            # through the unaligned buffer and failing.
+            fo = os.fdopen(fd, 'rb+', buffering=0)
         except OSError as exc:
             if exc.errno == errno.EINVAL:
                 raise ex.AbortAction("%s directio is not supported" % self.dev)

--- a/opensvc/drivers/resource/disk/md/__init__.py
+++ b/opensvc/drivers/resource/disk/md/__init__.py
@@ -92,6 +92,10 @@ def justcall_mdadm_detail(*args, **kwargs):
     return justcall(*args, **kwargs)
 
 
+def justcall_mdadm_detail_scan(*args, **kwargs):
+    return justcall(*args, **kwargs)
+
+
 def justcall_mdadm_scan(*args, **kwargs):
     return justcall(*args, **kwargs)
 
@@ -240,16 +244,35 @@ class DiskMd(BaseDisk):
         return [self.md_config_file_name()]
 
     def md_devpath(self):
+        """
+        Return the path of the assembled array.
+
+        The by-id path is the answer when udev made it. When it did not,
+        the array is looked for among the ones the kernel has assembled,
+        which "mdadm --detail --scan" reads from /proc/mdstat without
+        touching a device.
+
+        The examine scan is not the fallback here, unlike in has_it():
+        this returns a path only for an array that is assembled, and an
+        assembled array is one the kernel knows, so a scan of every
+        block device could not find one that "--detail --scan" missed.
+        It would only be the 44 seconds of io this driver stopped
+        spending, and it would be spent on the passive node of a
+        failover service, which is where the array is never assembled.
+        """
         devpath = self.devpath()
         if path_exists(devpath):
             return devpath
-        out, err, ret = self.mdadm_scan_v()
+        out, err, ret = self.mdadm_detail_scan()
         devname = self.devname()
         for line in out.splitlines():
+            words = line.split()
+            if len(words) < 2 or words[0] != "ARRAY":
+                continue
             if self._mdadm_scan_match(line, uuid=self.uuid, devname=devname):
-                devname = line.split()[1]
-                if path_exists(devname):
-                    return devname
+                scanned = words[1]
+                if path_exists(scanned):
+                    return scanned
         raise ex.Error("unable to find a devpath for md")
 
     def devname(self):
@@ -447,6 +470,18 @@ class DiskMd(BaseDisk):
     @cache("mdadm.scan.v")
     def mdadm_scan_v(self):
         return justcall_mdadm_scan(argv=[self.mdadm, "-E", "--scan", "-v"])
+
+    @cache("mdadm.detail.scan")
+    def mdadm_detail_scan(self):
+        """
+        Return the (out, err, ret) of a scan of the arrays the kernel
+        has assembled.
+
+        "mdadm --detail --scan" reads /proc/mdstat and asks the kernel
+        about the arrays it names, so it costs no device io, where
+        "mdadm -E --scan" examines every block device of the node.
+        """
+        return justcall_mdadm_detail_scan(argv=[self.mdadm, "--detail", "--scan"])
 
     @cache("blkid.scan")
     def blkid_scan(self):

--- a/opensvc/drivers/resource/sync/dds/__init__.py
+++ b/opensvc/drivers/resource/sync/dds/__init__.py
@@ -385,15 +385,16 @@ class SyncDds(Sync):
         if not self.svc_syncable():
             return
         self.get_info()
-        from multiprocessing import Process, Queue
+        from utilities.proc import fork_context
+        ctx = fork_context()
         self.checksums = {}
         queues = {}
         ps = []
         self.log.info("start checksum threads. please be patient.")
         for n in self.targets:
             dst = self.dsts[n]
-            queues[n] = Queue()
-            p = Process(target=self.checksum, args=(n, dst, queues[n]))
+            queues[n] = ctx.Queue()
+            p = ctx.Process(target=self.checksum, args=(n, dst, queues[n]))
             p.start()
             ps.append(p)
         self.checksum(Env.nodename, self.snap1)

--- a/opensvc/tests/daemon/hb/test_hb_disk.py
+++ b/opensvc/tests/daemon/hb/test_hb_disk.py
@@ -1,0 +1,78 @@
+import io
+import mmap
+import os
+
+import pytest
+
+from daemon.hb.disk import HbDisk
+
+
+def hb_with_dev(path):
+    """
+    A disk heartbeat opening path, without the node configuration a
+    configured one reads.
+    """
+    hb = HbDisk.__new__(HbDisk)
+    hb.dev = str(path)
+    hb.flags = os.O_RDWR | os.O_DIRECT
+    with open(hb.dev, "wb") as f:
+        f.write(b"\0" * (2 * 1024 * 1024))
+    return hb
+
+
+@pytest.mark.ci
+class TestHbDiskFileObject:
+    """
+    The heartbeat device is opened with O_DIRECT, which refuses a buffer that
+    is not page aligned.
+
+    The buffers this class reads into and writes from are mmap, so they are
+    aligned, but a buffered file object does not hand them to the file
+    descriptor: it reads and writes through an internal buffer of its own,
+    which is not aligned, unless the caller buffer is at least as large as it.
+
+    meta_slot_buff is two pages, which was exactly io.DEFAULT_BUFFER_SIZE
+    until python 3.14 raised it from 8kB to 128kB. The meta reads then began
+    going through the unaligned buffer, and every one of them failed with
+    EINVAL.
+    """
+
+    @staticmethod
+    def test_the_device_is_opened_unbuffered(tmp_path):
+        """
+        The one that holds on every python: a buffered object would only pass
+        the caller buffer through while it happens to be large enough.
+        """
+        hb = hb_with_dev(tmp_path / "hbdisk")
+        seen = []
+        with hb.hb_fo() as fo:
+            seen.append(fo)
+        assert isinstance(seen[0], io.RawIOBase), "the device must be opened unbuffered"
+
+    @staticmethod
+    def test_a_two_page_buffer_reads_and_writes(tmp_path):
+        """
+        The size that broke, meta_slot_buff being two pages long.
+
+        This one only fails where io.DEFAULT_BUFFER_SIZE is above two pages,
+        which is python 3.14 and later.
+        """
+        hb = hb_with_dev(tmp_path / "hbdisk")
+        buff = mmap.mmap(-1, 2 * mmap.PAGESIZE)
+        buff[0:5] = b"hello"
+
+        errs = []
+        with hb.hb_fo() as fo:
+            try:
+                fo.seek(mmap.PAGESIZE, os.SEEK_SET)
+                assert fo.write(buff) == 2 * mmap.PAGESIZE
+            except Exception as exc:
+                errs.append(exc)
+        with hb.hb_fo() as fo:
+            try:
+                fo.seek(mmap.PAGESIZE, os.SEEK_SET)
+                assert fo.readinto(buff) == 2 * mmap.PAGESIZE
+            except Exception as exc:
+                errs.append(exc)
+        assert errs == []
+        assert bytes(buff[0:5]) == b"hello"

--- a/opensvc/tests/resource/disk/md/test_md.py
+++ b/opensvc/tests/resource/disk/md/test_md.py
@@ -50,6 +50,16 @@ def mdadm_scan(mocker):
     return mocker.patch(LIB_NAME + '.justcall_mdadm_scan', return_value=(mdadm_scan_out, '', 0))
 
 
+mdadm_detail_scan_out = """ARRAY /dev/md/s.disk.1 metadata=1.2 name=node1:s.disk.1 UUID=s-uuid
+ARRAY /dev/md/ss.disk.1 metadata=1.2 name=node1:ss.disk.1 UUID=ss.uuid"""
+
+
+@pytest.fixture(scope='function')
+def mdadm_detail_scan(mocker):
+    return mocker.patch(LIB_NAME + '.justcall_mdadm_detail_scan',
+                        return_value=(mdadm_detail_scan_out, '', 0))
+
+
 @pytest.fixture(scope='function')
 def mdadm_detail(mocker):
     return mocker.patch(LIB_NAME + '.justcall_mdadm_detail', return_value=(detail_out, '', 0))
@@ -255,7 +265,7 @@ class TestDiskMdStatus:
         assert md_with_uuid._status() == DOWN
 
     @staticmethod
-    @pytest.mark.usefixtures('mdadm_scan')
+    @pytest.mark.usefixtures('mdadm_scan', 'mdadm_detail_scan')
     @pytest.mark.parametrize(
         'devs',
         [['/dev/disk/by-id/md-uuid-s-uuid'],
@@ -281,7 +291,7 @@ class TestDiskMdStatus:
         assert md_with_uuid._status() == DOWN
 
     @staticmethod
-    @pytest.mark.usefixtures('mdadm_detail', 'mdadm_scan')
+    @pytest.mark.usefixtures('mdadm_detail', 'mdadm_scan', 'mdadm_detail_scan')
     @pytest.mark.parametrize(
         'devs',
         [['/dev/disk/by-id/md-uuid-s-uuid'],
@@ -459,3 +469,62 @@ class TestDiskMdBlkid:
                      side_effect=lambda dev: ['/dev/sdx'] if dev == '/dev/loop4' else [dev])
         assert md_blkid.sub_devs_inactive() == {'/dev/loop4', '/dev/loop5'}
         assert mdadm_scan.call_count == 0
+
+
+@pytest.mark.ci
+@pytest.mark.usefixtures('osvc_path_tests')  # for cache
+@pytest.mark.usefixtures('has_mdadm')
+class TestDiskMdDevpath:
+    """
+    md_devpath() answers with the path of an assembled array. It asked
+    "mdadm -E --scan", which examines every block device of the node,
+    where "mdadm --detail --scan" asks the kernel about the arrays it
+    has already assembled.
+    """
+
+    @staticmethod
+    def test_the_by_id_path_is_the_answer_when_udev_made_it(
+            mdadm_scan, mdadm_detail_scan, has_files, md_with_uuid):
+        has_files(['/dev/disk/by-id/md-uuid-s-uuid'])
+        assert md_with_uuid.md_devpath() == '/dev/disk/by-id/md-uuid-s-uuid'
+        assert mdadm_scan.call_count == 0
+        assert mdadm_detail_scan.call_count == 0
+
+    @staticmethod
+    def test_the_array_is_found_without_examining_the_devices(
+            mdadm_scan, mdadm_detail_scan, has_files, md_with_uuid):
+        has_files(['/dev/md/s.disk.1'])
+        assert md_with_uuid.md_devpath() == '/dev/md/s.disk.1'
+        assert mdadm_detail_scan.call_count == 1
+        assert mdadm_scan.call_count == 0
+
+    @staticmethod
+    def test_an_absent_array_does_not_fall_back_to_the_examine_scan(
+            mdadm_scan, mdadm_detail_scan, has_files, md_with_uuid):
+        # The passive node of a failover service: the array is assembled
+        # nowhere here, and this is the case the examine scan was costing
+        # tens of seconds of io for.
+        has_files([])
+        md_with_uuid.uuid = 'not-a-uuid-of-this-node'
+        with pytest.raises(Error):
+            md_with_uuid.md_devpath()
+        assert mdadm_scan.call_count == 0
+
+    @staticmethod
+    def test_an_array_named_by_a_path_that_is_gone_is_not_the_answer(
+            mdadm_scan, mdadm_detail_scan, has_files, md_with_uuid):
+        # The scan names it, udev has not made the node.
+        has_files([])
+        with pytest.raises(Error):
+            md_with_uuid.md_devpath()
+        assert mdadm_detail_scan.call_count == 1
+        assert mdadm_scan.call_count == 0
+
+    @staticmethod
+    def test_the_lines_that_name_no_array_are_skipped(
+            mdadm_scan, mdadm_detail_scan, has_files, md_with_uuid):
+        mdadm_detail_scan.return_value = (
+            'mdadm: cannot open /dev/sdz: No such device\n'
+            + mdadm_detail_scan_out, '', 0)
+        has_files(['/dev/md/s.disk.1'])
+        assert md_with_uuid.md_devpath() == '/dev/md/s.disk.1'

--- a/opensvc/tests/test_resourceset.py
+++ b/opensvc/tests/test_resourceset.py
@@ -1,0 +1,76 @@
+import multiprocessing
+import os
+
+import pytest
+
+from core.objects.svc import Svc
+from core.resource import Resource
+from utilities.lazy import set_lazy
+
+
+class Marker(Resource):
+    """
+    A resource whose start leaves a file behind, so the parent can tell the
+    child really ran the action.
+    """
+
+    def __init__(self, rid, marker):
+        Resource.__init__(self, rid=rid, type="app.forking")
+        self.marker = marker
+
+    def start(self):
+        with open(self.marker, "w") as ofile:
+            ofile.write(str(os.getpid()))
+
+
+@pytest.fixture(name="start_method")
+def factory_start_method():
+    """
+    Force the way python starts a child process, and put back the one the
+    test session had.
+    """
+    previous = multiprocessing.get_start_method()
+
+    def set_start_method(method):
+        multiprocessing.set_start_method(method, force=True)
+
+    yield set_start_method
+    multiprocessing.set_start_method(previous, force=True)
+
+
+@pytest.mark.ci
+class TestParallelResourceSetAction:
+    @staticmethod
+    @pytest.mark.parametrize("method", ["fork", "forkserver", "spawn"])
+    def test_the_children_run_whatever_the_start_method_is(tmp_path, start_method, method):
+        """
+        The children of a parallel subset are forked, so they inherit the
+        service instead of being handed a pickle of it.
+
+        Python 3.14 made "forkserver" the default start method on linux, and
+        the service does not pickle: its pg lazy caches the process group
+        driver module, and a module is not picklable at all. Every parallel
+        subset action died in proc.start() with "cannot pickle 'module'
+        object" before the fork context was made explicit.
+        """
+        if method not in multiprocessing.get_all_start_methods():
+            pytest.skip("no %s start method on this platform" % method)
+        start_method(method)
+
+        svc = Svc(name="svc")
+        # a module, which is what the pg lazy caches on a real node
+        set_lazy(svc, "pg", multiprocessing)
+        markers = {}
+        for idx in range(2):
+            rid = "app#%d" % idx
+            markers[rid] = str(tmp_path / rid)
+            resource = Marker(rid, markers[rid])
+            resource.subset = "parallel"
+            svc += resource
+
+        rset = svc.get_resourcesets(["app"])[0]
+        rset.parallel = True
+        rset.action("start")
+
+        for rid, marker in markers.items():
+            assert os.path.exists(marker), "%s did not run its action" % rid

--- a/opensvc/tests/test_svc.py
+++ b/opensvc/tests/test_svc.py
@@ -72,3 +72,43 @@ class TestResourceHandlingDir:
         assert svc.resource_handling_dir("/a/b").mount_point is "/a/b"
         assert svc.resource_handling_dir("/a/b/c").mount_point is "/a/b/c"
         assert svc.resource_handling_dir("/a/b/c/d").mount_point is "/a/b/c"
+
+
+@pytest.mark.ci
+class TestSvcSurvivesPickling:
+    """
+    The parallel actions hand the service to a worker process. Python 3.14
+    made "forkserver" the default way of starting one on linux, which pickles
+    what it is handed instead of letting the child inherit it, so the service
+    now travels through a pickle.
+    """
+
+    @staticmethod
+    def test_the_keyword_store_is_still_the_one_of_the_process(svc):
+        """
+        kwstore has to be the KeywordStore of the process reading it.
+
+        It used to be a lazy, so it was cached on the service and pickled with
+        it, and the child unpickled a copy of the store its parent had. The
+        keywords a driver registers when it is imported went to the store of
+        the child, which nothing read, and every parallel action failed with
+        "sync#i0.options not found in the keywords dictionary".
+        """
+        import pickle
+
+        from core.objects.svcdict import KEYS
+
+        assert svc.kwstore is KEYS
+        assert pickle.loads(pickle.dumps(svc)).kwstore is KEYS
+
+    @staticmethod
+    def test_a_keyword_registered_after_the_pickle_is_seen(svc):
+        """
+        A driver imported after the service was pickled registers its
+        keywords in the store the unpickled service reads.
+        """
+        import pickle
+
+        clone = pickle.loads(pickle.dumps(svc))
+        svc.load_driver("sync", "rsync")
+        assert clone.kwstore["sync"].getkey("options", "rsync") is not None

--- a/opensvc/tests/utilities/test_proc.py
+++ b/opensvc/tests/utilities/test_proc.py
@@ -95,3 +95,33 @@ class TestLCall:
         get_updated_preexec_fn_mock = mocker.patch("utilities.proc.get_updated_preexec_fn")
         assert lcall([true_file], logging, preexec_fn=func) == 0
         get_updated_preexec_fn_mock.assert_called_once_with(func)
+
+
+@pytest.mark.ci
+class TestForkContext:
+    @staticmethod
+    @pytest.mark.skipif("fork" not in multiprocessing.get_all_start_methods(),
+                        reason="the platform has no fork")
+    def test_starts_the_children_with_fork(mocker):
+        """
+        Whatever start method python defaults to, and 3.14 defaults to
+        forkserver on linux, the children are forked.
+        """
+        mocker.patch.object(multiprocessing, "get_start_method", return_value="forkserver")
+        assert fork_context().get_start_method() == "fork"
+
+    @staticmethod
+    def test_fallback_on_the_default_context_where_there_is_no_fork(mocker):
+        """
+        Windows has no fork. The callers do not run there, so the default
+        context is good enough to hand them back.
+        """
+        default = multiprocessing.get_context()
+
+        def get_context(method=None):
+            if method == "fork":
+                raise ValueError("cannot find context for 'fork'")
+            return default
+
+        mocker.patch.object(multiprocessing, "get_context", side_effect=get_context)
+        assert fork_context() is default

--- a/opensvc/utilities/proc/__init__.py
+++ b/opensvc/utilities/proc/__init__.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import locale
 import logging
+import multiprocessing
 import os
 import select
 import shlex
@@ -48,6 +49,34 @@ def which(program):
                     return candidate
 
     return
+
+
+def fork_context():
+    """
+    The multiprocessing context to start the children of an action with.
+
+    Those children are forked, and not started by the method python picks by
+    default. Python 3.14 made that default "forkserver" on linux, where it was
+    "fork". A forkserver child is handed a pickle of the target and of its
+    arguments, where a forked child inherits the objects themselves, and what
+    is handed here does not survive that trip.
+
+    An object and its resources carry lazy caches of things that do not
+    pickle, the process group driver module first of all, so the pickling
+    raises "cannot pickle 'module' object". Those that do pickle come back in
+    the child as copies of process globals that nothing else in that process
+    shares, the keyword store first of all, so the child reads a store the
+    driver imports of that same child do not register their keywords in.
+
+    Platforms with no fork, windows, get the default context. Nothing that
+    calls this runs there: the parallel resource set actions are serialized on
+    windows, and the other callers hand a child a nested function, which no
+    pickle-based start method has ever been able to carry.
+    """
+    try:
+        return multiprocessing.get_context("fork")
+    except ValueError:
+        return multiprocessing.get_context()
 
 
 def oom_score_adj(pid="self", value=0):


### PR DESCRIPTION
md_devpath() is the codepath the blkid work missed. When udev has not made /dev/disk/by-id/md-uuid-<uuid>, it fell back to "mdadm -E --scan -v", which is the scan of every lun that has_it() stopped running, and the 44 seconds a client site measured. So a node that had its status evaluation back paid the scan again as soon as the by-id name was absent.

"mdadm --detail --scan" answers the same question for the price of reading /proc/mdstat: it names the arrays the kernel has assembled, and asks the kernel about those alone, so it touches no device. That is enough here, because md_devpath() returns a path only for an assembled array, and an assembled array is one the kernel knows.

Where has_it() keeps the examine scan as its fallback, this has none. A scan of every device cannot find an assembled array that --detail --scan missed, so it would only spend the 44 seconds again, and spend them on the passive node of a failover service, which is where the array is never assembled and where this most needs to stop scanning.

The loop also skips the lines that name no array: mdadm writes its warnings to stdout, and line.split()[1] read the second word of one as a device path.

Five tests cover the paths, including the negative control that the examine scan is not run for an array this node does not hold. Two status tests that reach md_devpath() through a scan gained the fixture for it. The suite is at 49 passing, from 44.

Confirmed closed by testing at the client site.